### PR TITLE
Add random generation for healthcare, telecom, and tax IDs

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -80,7 +80,7 @@ Legend: **V** = validate, **G** = generate (where safe).
 - NL: BSN, BTW
 - PL: NIP, REGON, PESEL
 - SE: Personnummer, OrgNr
-- US: SSN, EIN, ITIN
+- US: SSN — V/G, EIN, ITIN
 - BR: CPF, CNPJ
 - CA: SIN, BN
 - IN: PAN, GSTIN
@@ -116,14 +116,14 @@ Legend: **V** = validate, **G** = generate (where safe).
 - IMO ship identification number
 
 ### Healthcare & Pharma
-- NHS Number
-- ORCID
+- NHS Number — V/G
+- ORCID — V/G
 
 ### Telecom & IT
 - IMEI
 - MEID
 - ICCID
-- MAC
+- MAC — V/G
 - OUI
 - ASN
 - IPv4 / IPv6

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Core primitives and algorithms for identifier validation and generation.
 - Germany IdNr validation/generation
 - Canada SIN validation/generation
 - Canada Business Number validation/generation
-- United States SSN structural validation
+- United States SSN structural validation and generation
 - United Kingdom NINO structural validation
 - United Kingdom UTR checksum validation
 - United Kingdom VAT checksum validation
@@ -100,7 +100,7 @@ Core primitives and algorithms for identifier validation and generation.
 - IMEI validation and generation
 - MEID validation and generation
 - ICCID validation and generation
-- MAC address validation
+- MAC address validation and generation
 - OUI validation and generation
 - ASN validation and generation
 - IPv4 structural validation
@@ -116,8 +116,8 @@ Core primitives and algorithms for identifier validation and generation.
 - ISRC structural validation
 
 ### Healthcare
-- NHS Number validation
-- ORCID validation
+- NHS Number validation and generation
+- ORCID validation and generation
 
 Additional identifiers and algorithms will be added per the [PRD](PRD.md).
 

--- a/src/Veritas/Healthcare/NhsNumber.cs
+++ b/src/Veritas/Healthcare/NhsNumber.cs
@@ -27,4 +27,31 @@ public static class NhsNumber
         result = new ValidationResult<NhsNumberValue>(true, new NhsNumberValue(new string(digits)), ValidationError.None);
         return true;
     }
+
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 10)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        Span<char> digits = destination;
+        while (true)
+        {
+            for (int i = 0; i < 9; i++)
+                digits[i] = (char)('0' + rng.Next(10));
+            int sum = 0;
+            for (int i = 0; i < 9; i++) sum += (10 - i) * (digits[i] - '0');
+            int check = 11 - (sum % 11);
+            if (check == 11) check = 0;
+            if (check == 10) continue;
+            digits[9] = (char)('0' + check);
+            written = 10;
+            return true;
+        }
+    }
 }

--- a/src/Veritas/Healthcare/Orcid.cs
+++ b/src/Veritas/Healthcare/Orcid.cs
@@ -25,4 +25,22 @@ public static class Orcid
         result = new ValidationResult<OrcidValue>(true, new OrcidValue(new string(digits)), ValidationError.None);
         return true;
     }
+
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 16)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 15; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        destination[15] = Iso7064.ComputeCheckDigitMod11_2(destination[..15]);
+        written = 16;
+        return true;
+    }
 }

--- a/src/Veritas/Tax/US/Ssn.cs
+++ b/src/Veritas/Tax/US/Ssn.cs
@@ -27,4 +27,35 @@ public static class Ssn
         result = new ValidationResult<SsnValue>(true, new SsnValue(new string(digits)), ValidationError.None);
         return true;
     }
+
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 9)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        int area;
+        do
+        {
+            area = rng.Next(1, 900); // 001-899
+        } while (area == 666);
+        int group = rng.Next(1, 100); // 01-99
+        int serial = rng.Next(1, 10000); // 0001-9999
+        destination[0] = (char)('0' + area / 100);
+        destination[1] = (char)('0' + (area / 10) % 10);
+        destination[2] = (char)('0' + area % 10);
+        destination[3] = (char)('0' + group / 10);
+        destination[4] = (char)('0' + group % 10);
+        destination[5] = (char)('0' + serial / 1000);
+        destination[6] = (char)('0' + (serial / 100) % 10);
+        destination[7] = (char)('0' + (serial / 10) % 10);
+        destination[8] = (char)('0' + serial % 10);
+        written = 9;
+        return true;
+    }
 }

--- a/src/Veritas/Telecom/Mac.cs
+++ b/src/Veritas/Telecom/Mac.cs
@@ -23,4 +23,22 @@ public static class Mac
         result = new ValidationResult<MacValue>(true, new MacValue(new string(buf)), ValidationError.None);
         return true;
     }
+
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 12)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        const string hex = "0123456789ABCDEF";
+        for (int i = 0; i < 12; i++)
+            destination[i] = hex[rng.Next(16)];
+        written = 12;
+        return true;
+    }
 }

--- a/test/Veritas.Tests/Healthcare/NhsNumberTests.cs
+++ b/test/Veritas.Tests/Healthcare/NhsNumberTests.cs
@@ -12,4 +12,13 @@ public class NhsNumberTests
         NhsNumber.TryValidate(input, out var r);
         r.IsValid.ShouldBe(expected);
     }
+
+    [Fact]
+    public void GenerateProducesValid()
+    {
+        Span<char> buffer = stackalloc char[10];
+        NhsNumber.TryGenerate(buffer, out var written).ShouldBeTrue();
+        NhsNumber.TryValidate(buffer[..written], out var r);
+        r.IsValid.ShouldBeTrue();
+    }
 }

--- a/test/Veritas.Tests/Healthcare/OrcidTests.cs
+++ b/test/Veritas.Tests/Healthcare/OrcidTests.cs
@@ -10,6 +10,15 @@ public class OrcidTests
     public void Validate(string input, bool expected)
     {
         Orcid.TryValidate(input, out var r);
-        r.IsValid.ShouldBe(expected);
+       r.IsValid.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GenerateProducesValid()
+    {
+        Span<char> buffer = stackalloc char[16];
+        Orcid.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Orcid.TryValidate(buffer[..written], out var r);
+        r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/US/SsnTests.cs
+++ b/test/Veritas.Tests/Tax/US/SsnTests.cs
@@ -12,4 +12,13 @@ public class SsnTests
         Ssn.TryValidate(input, out var r);
         r.IsValid.ShouldBe(expected);
     }
+
+    [Fact]
+    public void GenerateProducesValid()
+    {
+        Span<char> buffer = stackalloc char[9];
+        Ssn.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Ssn.TryValidate(buffer[..written], out var r);
+        r.IsValid.ShouldBeTrue();
+    }
 }

--- a/test/Veritas.Tests/Telecom/MacTests.cs
+++ b/test/Veritas.Tests/Telecom/MacTests.cs
@@ -12,4 +12,13 @@ public class MacTests
         Mac.TryValidate(input, out var r);
         r.IsValid.ShouldBe(expected);
     }
+
+    [Fact]
+    public void GenerateProducesValid()
+    {
+        Span<char> buffer = stackalloc char[12];
+        Mac.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Mac.TryValidate(buffer[..written], out var r);
+        r.IsValid.ShouldBeTrue();
+    }
 }


### PR DESCRIPTION
## Summary
- add random generator helpers for MAC addresses, NHS numbers, ORCID identifiers, and US SSNs
- document generation support for the new identifiers in README and PRD
- cover new generators with unit tests

## Testing
- `dotnet test -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_68bcaa5e8148832bb2a6334980899c41