### PR TITLE
Add docs workflow and setup guide

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: docs
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup dotnet
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: install docfx
+        run: dotnet tool update -g docfx
+
+      - name: build docs
+        run: docfx docfx/docfx.json
+
+      - name: publish to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docfx/_site

--- a/docs.md
+++ b/docs.md
@@ -1,0 +1,15 @@
+# Documentation Setup
+
+This repository uses [DocFX](https://dotnet.github.io/docfx/) to build API documentation and publish the static site to GitHub Pages. A GitHub Actions workflow at `.github/workflows/docs.yml` runs on every release to generate and deploy the docs.
+
+## Initial setup
+
+1. Ensure a DocFX configuration exists at `docfx/docfx.json`. If you need a starting point, run `docfx init -q` and customize the generated files.
+2. Enable GitHub Pages:
+   - Go to **Settings → Pages**.
+   - Under **Build and deployment**, choose **Deploy from a branch**.
+   - Select the `gh-pages` branch and `/` (root) folder.
+
+After publishing a release, the workflow will build the docs with DocFX and publish them to GitHub Pages automatically.
+
+For a detailed walkthrough of this process, see [Steven Giesel's blog post](https://steven-giesel.com/blogPost/5f9e9f0d-2413-4e4b-8e38-9eebe9503e52).


### PR DESCRIPTION
## Summary
- build and publish DocFX documentation on release
- document how to configure DocFX and enable GitHub Pages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bcc67dd85c832bab67b04ab74067b2