### PR TITLE
Add DocFX configuration and ignore generated output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,7 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+# DocFX generated output
+docfx/_site/
+docfx/api/

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/docfx/main/schemas/docfx.schema.json",
+  "metadata": [
+    {
+      "src": [
+        {
+          "src": "../src",
+          "files": [
+            "**/*.csproj"
+          ]
+        }
+      ],
+      "dest": "api"
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "**/*.{md,yml}"
+        ],
+        "exclude": [
+          "_site/**"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          "images/**"
+        ]
+      }
+    ],
+    "output": "_site",
+    "template": [
+      "default",
+      "modern"
+    ],
+    "globalMetadata": {
+      "_appName": "",
+      "_appTitle": "",
+      "_enableSearch": true,
+      "pdf": false
+    }
+  }
+}

--- a/docfx/docs/getting-started.md
+++ b/docfx/docs/getting-started.md
@@ -1,0 +1,1 @@
+# Getting Started

--- a/docfx/docs/introduction.md
+++ b/docfx/docs/introduction.md
@@ -1,0 +1,1 @@
+# Introduction

--- a/docfx/docs/toc.yml
+++ b/docfx/docs/toc.yml
@@ -1,0 +1,4 @@
+- name: Introduction
+  href: introduction.md
+- name: Getting Started
+  href: getting-started.md

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -1,0 +1,11 @@
+---
+_layout: landing
+---
+
+# This is the **HOMEPAGE**.
+
+Refer to [Markdown](http://daringfireball.net/projects/markdown/) for how to write markdown files.
+
+## Quick Start Notes:
+
+1. Add images to the *images* folder if the file is referencing an image.

--- a/docfx/toc.yml
+++ b/docfx/toc.yml
@@ -1,0 +1,4 @@
+- name: Docs
+  href: docs/
+- name: API
+  href: api/


### PR DESCRIPTION
## Summary
- set up DocFX project for generating API docs
- ignore DocFX build artifacts and disable PDF generation

## Testing
- `docfx docfx/docfx.json`
- `dotnet test -f net8.0` *(fails: TfnTests.GenerateProducesValid)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a42fbdfc832bbefd9019e6eebb45