### PR TITLE
Add generator for UK UTR numbers

### DIFF
--- a/src/Veritas/Tax/UK/Utr.cs
+++ b/src/Veritas/Tax/UK/Utr.cs
@@ -41,6 +41,29 @@ public static class Utr
         return true;
     }
 
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 10)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        int sum = 0;
+        for (int i = 0; i < 9; i++)
+        {
+            int d = rng.Next(10);
+            destination[i + 1] = (char)('0' + d);
+            sum += d * Weights[i];
+        }
+        destination[0] = Map[sum % 11];
+        written = 10;
+        return true;
+    }
+
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
     {
         len = 0;

--- a/test/Veritas.Tests/Tax/UK/UtrTests.cs
+++ b/test/Veritas.Tests/Tax/UK/UtrTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Veritas.Tax.UK;
 using Xunit;
 using Shouldly;
@@ -6,11 +7,24 @@ public class UtrTests
 {
     [Theory]
     [InlineData("1123456789", true)]
+    [InlineData("7660487647", true)]
     [InlineData("2123456789", false)]
+    [InlineData("1123456780", false)]
+    [InlineData("123456789", false)]
+    [InlineData("11234A6789", false)]
     public void Validate(string input, bool expected)
     {
         Utr.TryValidate(input, out var r);
         r.IsValid.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GenerateProducesValid()
+    {
+        Span<char> buffer = stackalloc char[10];
+        Utr.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Utr.TryValidate(buffer[..written], out var r);
+        r.IsValid.ShouldBeTrue();
     }
 }
 


### PR DESCRIPTION
## Summary
- add generator for UK Unique Taxpayer Reference (UTR)
- expand UTR tests with multiple valid/invalid cases
- include generator smoke test

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68c0b1823ee0832bb43ed6c849d783ec