### PR TITLE
Add Verhoeff and Damm checksums with new identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ dotnet add package Veritas --version 1.0.3
 - ISO 6346 container check digit
 - MRZ (ICAO 9303 7-3-1 pattern)
 - Base58Check codec
+- Verhoeff checksum
+- Damm checksum
 
 ### Finance
 - IBAN validation (ISO 13616 / ISO 7064 mod 97)
@@ -64,6 +66,8 @@ dotnet add package Veritas --version 1.0.3
 - BCP 47 language tag validation
 - Ethereum address validation
 - Base58Check validation and generation
+- India Aadhaar validation and generation
+- Luxembourg National ID validation and generation
 
 ### Tax
 - Brazil CPF validation/generation
@@ -118,6 +122,9 @@ dotnet add package Veritas --version 1.0.3
 - IPv4 structural validation
 - IPv6 structural validation
 
+### IP
+- Singapore IPOS application number validation and generation
+
 ### Education & Media
 - ISBN-10 validation and generation
 - ISBN-13 validation and generation
@@ -130,6 +137,7 @@ dotnet add package Veritas --version 1.0.3
 ### Healthcare
 - NHS Number validation and generation
 - ORCID validation and generation
+- SNOMED CT Concept ID validation and generation
 
 Additional identifiers and algorithms will be added per the [PRD](PRD.md).
 

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -90,6 +90,8 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | BCP47 tag | Global | structural check | <xref:Veritas.Identity.Bcp47> |
 | Ethereum address | Global | EIP-55 checksum | <xref:Veritas.Identity.Ethereum> |
 | Base58Check | Global | Base58 + double SHA-256 | <xref:Veritas.Identity.Base58Check> |
+| Aadhaar | India | Verhoeff checksum; test generation | <xref:Veritas.Identity.India.Aadhaar> |
+| National ID | Luxembourg | Luhn + Verhoeff; test generation | <xref:Veritas.Identity.Luxembourg.NationalId> |
 
 ### Tax
 
@@ -154,6 +156,12 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | IPv4 | Global | structural check | <xref:Veritas.Telecom.Ipv4> |
 | IPv6 | Global | structural check | <xref:Veritas.Telecom.Ipv6> |
 
+### IP
+
+| Identifier | Country/Region | Validation & Generation | Docs |
+|------------|----------------|-------------------------|------|
+| IPOS Application Number | Singapore | Damm checksum; test generation | <xref:Veritas.IP.Singapore.IpApplicationNumber> |
+
 ### Education & Media
 
 | Identifier | Country/Region | Validation & Generation | Docs |
@@ -172,6 +180,7 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 |------------|----------------|-------------------------|------|
 | NHS Number | UK | mod 11 checksum; generation | <xref:Veritas.Healthcare.NhsNumber> |
 | ORCID | International | ISO 7064 mod 11,2 checksum; generation | <xref:Veritas.Healthcare.Orcid> |
+| SNOMED CT Concept ID | International | Verhoeff checksum; test generation | <xref:Veritas.Healthcare.Snomed.SctId> |
 
 ## Future identifiers
 

--- a/src/Veritas/Checksums/Damm.cs
+++ b/src/Veritas/Checksums/Damm.cs
@@ -1,0 +1,57 @@
+namespace Veritas.Checksums;
+
+/// <summary>Provides the Damm quasigroup checksum algorithm.</summary>
+public static class Damm
+{
+    private static readonly int[,] table = new int[,]
+    {
+        {0,3,1,7,5,9,8,6,4,2},
+        {7,0,9,2,1,5,4,8,6,3},
+        {4,2,0,6,8,7,1,3,5,9},
+        {1,7,5,0,9,8,3,4,2,6},
+        {6,1,2,3,0,4,5,9,7,8},
+        {3,6,7,4,2,0,9,5,8,1},
+        {5,8,6,9,7,2,0,1,3,4},
+        {8,9,4,5,3,6,2,0,1,7},
+        {9,4,3,8,6,1,7,2,0,5},
+        {2,5,8,1,4,3,6,7,9,0}
+    };
+
+    /// <summary>Computes the Damm check digit for the supplied numeric string.</summary>
+    public static byte Compute(ReadOnlySpan<char> digits)
+    {
+        int c = 0;
+        foreach (var ch in digits)
+        {
+            int d = ch - '0';
+            if ((uint)d > 9) throw new ArgumentException("Non-digit character", nameof(digits));
+            c = table[c, d];
+        }
+        return (byte)c;
+    }
+
+    /// <summary>Validates a sequence with an appended Damm check digit.</summary>
+    public static bool Validate(ReadOnlySpan<char> digitsWithCheck)
+    {
+        int c = 0;
+        foreach (var ch in digitsWithCheck)
+        {
+            int d = ch - '0';
+            if ((uint)d > 9) return false;
+            c = table[c, d];
+        }
+        return c == 0;
+    }
+
+    /// <summary>Appends the Damm check digit to the destination buffer.</summary>
+    public static bool Append(ReadOnlySpan<char> digits, Span<char> destination, out int written)
+    {
+        written = 0;
+        if (destination.Length < digits.Length + 1) return false;
+        digits.CopyTo(destination);
+        destination[digits.Length] = (char)('0' + Compute(digits));
+        written = digits.Length + 1;
+        return true;
+    }
+}
+

--- a/src/Veritas/Checksums/Verhoeff.cs
+++ b/src/Veritas/Checksums/Verhoeff.cs
@@ -1,0 +1,79 @@
+namespace Veritas.Checksums;
+
+/// <summary>Provides the Verhoeff check digit algorithm.</summary>
+public static class Verhoeff
+{
+    private static readonly int[,] d = new int[,]
+    {
+        {0,1,2,3,4,5,6,7,8,9},
+        {1,2,3,4,0,6,7,8,9,5},
+        {2,3,4,0,1,7,8,9,5,6},
+        {3,4,0,1,2,8,9,5,6,7},
+        {4,0,1,2,3,9,5,6,7,8},
+        {5,9,8,7,6,0,4,3,2,1},
+        {6,5,9,8,7,1,0,4,3,2},
+        {7,6,5,9,8,2,1,0,4,3},
+        {8,7,6,5,9,3,2,1,0,4},
+        {9,8,7,6,5,4,3,2,1,0}
+    };
+
+    private static readonly int[,] p = new int[,]
+    {
+        {0,1,2,3,4,5,6,7,8,9},
+        {1,5,7,6,2,8,3,0,9,4},
+        {5,8,0,3,7,9,6,1,4,2},
+        {8,9,1,6,0,4,3,5,2,7},
+        {9,4,5,3,1,2,6,8,7,0},
+        {4,2,8,6,5,7,3,9,0,1},
+        {2,7,9,3,8,0,6,4,1,5},
+        {7,0,4,6,9,1,3,2,5,8}
+    };
+
+    private static readonly int[] inv = {0,4,3,2,1,5,6,7,8,9};
+
+    /// <summary>Computes the Verhoeff check digit for the supplied numeric string.</summary>
+    /// <param name="digits">Digits without the check digit.</param>
+    /// <returns>The computed check digit 0-9.</returns>
+    public static byte Compute(ReadOnlySpan<char> digits)
+    {
+        int c = 0;
+        for (int i = 0; i < digits.Length; i++)
+        {
+            int dVal = digits[digits.Length - 1 - i] - '0';
+            if ((uint)dVal > 9) throw new ArgumentException("Non-digit character", nameof(digits));
+            c = d[c, p[(i + 1) % 8, dVal]];
+        }
+        return (byte)inv[c];
+    }
+
+    /// <summary>Validates a sequence with an appended Verhoeff check digit.</summary>
+    /// <param name="digitsWithCheck">Digits including the check digit as the final character.</param>
+    /// <returns><c>true</c> if the sequence is valid; otherwise <c>false</c>.</returns>
+    public static bool Validate(ReadOnlySpan<char> digitsWithCheck)
+    {
+        int c = 0;
+        for (int i = 0; i < digitsWithCheck.Length; i++)
+        {
+            int dVal = digitsWithCheck[digitsWithCheck.Length - 1 - i] - '0';
+            if ((uint)dVal > 9) return false;
+            c = d[c, p[i % 8, dVal]];
+        }
+        return c == 0;
+    }
+
+    /// <summary>Appends the Verhoeff check digit to the specified destination buffer.</summary>
+    /// <param name="digits">Digits without the check digit.</param>
+    /// <param name="destination">Buffer that receives digits plus check digit.</param>
+    /// <param name="written">Number of characters written.</param>
+    /// <returns><c>true</c> if the destination had sufficient space.</returns>
+    public static bool Append(ReadOnlySpan<char> digits, Span<char> destination, out int written)
+    {
+        written = 0;
+        if (destination.Length < digits.Length + 1) return false;
+        digits.CopyTo(destination);
+        destination[digits.Length] = (char)('0' + Compute(digits));
+        written = digits.Length + 1;
+        return true;
+    }
+}
+

--- a/src/Veritas/Healthcare/Snomed/SctId.cs
+++ b/src/Veritas/Healthcare/Snomed/SctId.cs
@@ -1,0 +1,57 @@
+using Veritas.Checksums;
+
+namespace Veritas.Healthcare.Snomed;
+
+/// <summary>Provides validation and generation for SNOMED CT Concept IDs.</summary>
+public static class SctId
+{
+    private const int MinLength = 6;
+    private const int MaxLength = 18;
+
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<SctIdValue> result)
+    {
+        Span<char> digits = stackalloc char[MaxLength];
+        if (!Normalize(input, digits, out int len) || len < MinLength || len > MaxLength)
+        {
+            result = new ValidationResult<SctIdValue>(false, default, ValidationError.Length);
+            return true;
+        }
+        if (!Verhoeff.Validate(digits[..len]))
+        {
+            result = new ValidationResult<SctIdValue>(false, default, ValidationError.Checksum);
+            return true;
+        }
+        var value = new string(digits[..len]);
+        result = new ValidationResult<SctIdValue>(true, new SctIdValue(value), ValidationError.None);
+        return true;
+    }
+
+    public static bool TryGenerate(int length, Span<char> destination, out int written)
+        => TryGenerate(length, default, destination, out written);
+
+    public static bool TryGenerate(int length, in GenerationOptions options, Span<char> destination, out int written)
+    {
+        written = 0;
+        if (length < MinLength || length > MaxLength) return false;
+        if (destination.Length < length) return false;
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < length - 1; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        destination[length - 1] = (char)('0' + Verhoeff.Compute(destination[..(length - 1)]));
+        written = length;
+        return true;
+    }
+
+    private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
+    {
+        len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
+        }
+        return true;
+    }
+}

--- a/src/Veritas/Healthcare/Snomed/SctIdValue.cs
+++ b/src/Veritas/Healthcare/Snomed/SctIdValue.cs
@@ -1,0 +1,9 @@
+namespace Veritas.Healthcare.Snomed;
+
+/// <summary>Represents a validated SNOMED CT Concept ID.</summary>
+public readonly struct SctIdValue
+{
+    public string Value { get; }
+    public SctIdValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/src/Veritas/IP/Singapore/IpApplicationNumber.cs
+++ b/src/Veritas/IP/Singapore/IpApplicationNumber.cs
@@ -1,0 +1,79 @@
+using Veritas.Checksums;
+
+namespace Veritas.IP.Singapore;
+
+/// <summary>Validation and generation for Singapore IPOS application numbers.</summary>
+public static class IpApplicationNumber
+{
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<IpApplicationNumberValue> result)
+    {
+        Span<char> buf = stackalloc char[12];
+        if (!Normalize(input, buf, out int len) || len != 12)
+        {
+            result = new ValidationResult<IpApplicationNumberValue>(false, default, ValidationError.Length);
+            return true;
+        }
+        if (!char.IsLetter(buf[0]) || !char.IsLetter(buf[1]))
+        {
+            result = new ValidationResult<IpApplicationNumberValue>(false, default, ValidationError.Format);
+            return true;
+        }
+        for (int i = 2; i < 12; i++)
+        {
+            if (!char.IsDigit(buf[i]))
+            {
+                result = new ValidationResult<IpApplicationNumberValue>(false, default, ValidationError.Format);
+                return true;
+            }
+        }
+        byte check = Damm.Compute(buf.Slice(2, 9));
+        if (buf[11] != (char)('0' + check))
+        {
+            result = new ValidationResult<IpApplicationNumberValue>(false, default, ValidationError.Checksum);
+            return true;
+        }
+        var value = new string(buf);
+        result = new ValidationResult<IpApplicationNumberValue>(true, new IpApplicationNumberValue(value), ValidationError.None);
+        return true;
+    }
+
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        written = 0;
+        if (destination.Length < 12) return false;
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        destination[0] = (char)('A' + rng.Next(26));
+        destination[1] = (char)('A' + rng.Next(26));
+        for (int i = 2; i < 11; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        destination[11] = (char)('0' + Damm.Compute(destination.Slice(2, 9)));
+        written = 12;
+        return true;
+    }
+
+    private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
+    {
+        len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ') continue;
+            if (ch == '-') break; // stop at sub-designation
+            if (char.IsLetter(ch))
+            {
+                if (len >= dest.Length) { len = 0; return false; }
+                dest[len++] = char.ToUpperInvariant(ch);
+            }
+            else if (char.IsDigit(ch))
+            {
+                if (len >= dest.Length) { len = 0; return false; }
+                dest[len++] = ch;
+            }
+            else
+            {
+                len = 0;
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/Veritas/IP/Singapore/IpApplicationNumberValue.cs
+++ b/src/Veritas/IP/Singapore/IpApplicationNumberValue.cs
@@ -1,0 +1,9 @@
+namespace Veritas.IP.Singapore;
+
+/// <summary>Represents a validated Singapore IPOS application number.</summary>
+public readonly struct IpApplicationNumberValue
+{
+    public string Value { get; }
+    public IpApplicationNumberValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/src/Veritas/Identity/India/Aadhaar.cs
+++ b/src/Veritas/Identity/India/Aadhaar.cs
@@ -1,0 +1,65 @@
+using Veritas.Checksums;
+
+namespace Veritas.Identity.India;
+
+/// <summary>Provides validation and generation for Indian Aadhaar numbers.</summary>
+public static class Aadhaar
+{
+    /// <summary>Attempts to validate the supplied input as an Aadhaar number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<AadhaarValue> result)
+    {
+        Span<char> digits = stackalloc char[12];
+        if (!Normalize(input, digits, out int len) || len != 12)
+        {
+            result = new ValidationResult<AadhaarValue>(false, default, ValidationError.Length);
+            return true;
+        }
+        bool allSame = true;
+        for (int i = 1; i < 12; i++)
+            if (digits[i] != digits[0]) { allSame = false; break; }
+        if (allSame)
+        {
+            result = new ValidationResult<AadhaarValue>(false, default, ValidationError.Format);
+            return true;
+        }
+        if (!Verhoeff.Validate(digits))
+        {
+            result = new ValidationResult<AadhaarValue>(false, default, ValidationError.Checksum);
+            return true;
+        }
+        var value = new string(digits);
+        result = new ValidationResult<AadhaarValue>(true, new AadhaarValue(value), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a test Aadhaar number.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        written = 0;
+        if (destination.Length < 12) return false;
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 11; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        bool allSame = true;
+        for (int i = 1; i < 11; i++)
+            if (destination[i] != destination[0]) { allSame = false; break; }
+        if (allSame)
+            destination[10] = destination[10] == '0' ? '1' : '0';
+        destination[11] = (char)('0' + Verhoeff.Compute(destination[..11]));
+        written = 12;
+        return true;
+    }
+
+    private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
+    {
+        len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
+        }
+        return true;
+    }
+}

--- a/src/Veritas/Identity/India/AadhaarValue.cs
+++ b/src/Veritas/Identity/India/AadhaarValue.cs
@@ -1,0 +1,13 @@
+namespace Veritas.Identity.India;
+
+/// <summary>Represents a validated Indian Aadhaar number.</summary>
+public readonly struct AadhaarValue
+{
+    /// <summary>Gets the normalized Aadhaar string.</summary>
+    public string Value { get; }
+
+    /// <summary>Creates a new <see cref="AadhaarValue"/>.</summary>
+    public AadhaarValue(string value) => Value = value;
+
+    public override string ToString() => Value;
+}

--- a/src/Veritas/Identity/Luxembourg/NationalId.cs
+++ b/src/Veritas/Identity/Luxembourg/NationalId.cs
@@ -1,0 +1,59 @@
+using Veritas.Checksums;
+using Veritas.Algorithms;
+
+namespace Veritas.Identity.Luxembourg;
+
+/// <summary>Provides validation and generation for Luxembourg National ID numbers.</summary>
+public static class NationalId
+{
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<NationalIdValue> result)
+    {
+        Span<char> digits = stackalloc char[13];
+        if (!Normalize(input, digits, out int len) || len != 13)
+        {
+            result = new ValidationResult<NationalIdValue>(false, default, ValidationError.Length);
+            return true;
+        }
+        byte luhn = (byte)Luhn.ComputeCheckDigit(digits[..11]);
+        if (digits[11] != (char)('0' + luhn))
+        {
+            result = new ValidationResult<NationalIdValue>(false, default, ValidationError.Checksum);
+            return true;
+        }
+        byte ver = Verhoeff.Compute(digits[..11]);
+        if (digits[12] != (char)('0' + ver))
+        {
+            result = new ValidationResult<NationalIdValue>(false, default, ValidationError.Checksum);
+            return true;
+        }
+        var value = new string(digits);
+        result = new ValidationResult<NationalIdValue>(true, new NationalIdValue(value), ValidationError.None);
+        return true;
+    }
+
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        written = 0;
+        if (destination.Length < 13) return false;
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 11; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        destination[11] = (char)('0' + Luhn.ComputeCheckDigit(destination[..11]));
+        destination[12] = (char)('0' + Verhoeff.Compute(destination[..11]));
+        written = 13;
+        return true;
+    }
+
+    private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
+    {
+        len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
+        }
+        return true;
+    }
+}

--- a/src/Veritas/Identity/Luxembourg/NationalIdValue.cs
+++ b/src/Veritas/Identity/Luxembourg/NationalIdValue.cs
@@ -1,0 +1,9 @@
+namespace Veritas.Identity.Luxembourg;
+
+/// <summary>Represents a validated Luxembourg National ID.</summary>
+public readonly struct NationalIdValue
+{
+    public string Value { get; }
+    public NationalIdValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/test/Veritas.Tests/Checksums/DammTests.cs
+++ b/test/Veritas.Tests/Checksums/DammTests.cs
@@ -1,0 +1,20 @@
+using Veritas.Checksums;
+using Xunit;
+using Shouldly;
+
+public class DammTests
+{
+    [Fact]
+    public void Compute_Sample()
+    {
+        Damm.Compute("572").ShouldBe((byte)4);
+    }
+
+    [Theory]
+    [InlineData("5724", true)]
+    [InlineData("5727", false)]
+    public void Validate_Sample(string input, bool expected)
+    {
+        Damm.Validate(input).ShouldBe(expected);
+    }
+}

--- a/test/Veritas.Tests/Checksums/VerhoeffTests.cs
+++ b/test/Veritas.Tests/Checksums/VerhoeffTests.cs
@@ -1,0 +1,28 @@
+using Veritas.Checksums;
+using Xunit;
+using Shouldly;
+
+public class VerhoeffTests
+{
+    [Fact]
+    public void Compute_Sample()
+    {
+        Verhoeff.Compute("2363").ShouldBe((byte)4);
+    }
+
+    [Theory]
+    [InlineData("23634", true)]
+    [InlineData("23635", false)]
+    public void Validate_Sample(string input, bool expected)
+    {
+        Verhoeff.Validate(input).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Append_AppendsCheck()
+    {
+        Span<char> dest = stackalloc char[5];
+        Verhoeff.Append("2363", dest, out var written).ShouldBeTrue();
+        new string(dest[..written]).ShouldBe("23634");
+    }
+}

--- a/test/Veritas.Tests/Healthcare/Snomed/SctIdTests.cs
+++ b/test/Veritas.Tests/Healthcare/Snomed/SctIdTests.cs
@@ -1,0 +1,30 @@
+using Veritas.Healthcare.Snomed;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class SctIdTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[10];
+        SctId.TryGenerate(10, new GenerationOptions { Seed = 42 }, dst, out var written).ShouldBeTrue();
+        var s = new string(dst[..written]);
+        SctId.TryValidate(s, out var r);
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_Checksum()
+    {
+        Span<char> dst = stackalloc char[9];
+        SctId.TryGenerate(9, new GenerationOptions { Seed = 1 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        // corrupt last digit
+        char bad = s[^1] == '0' ? '1' : '0';
+        var badStr = s[..^1] + bad;
+        SctId.TryValidate(badStr, out var r);
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/IP/Singapore/IpApplicationNumberTests.cs
+++ b/test/Veritas.Tests/IP/Singapore/IpApplicationNumberTests.cs
@@ -1,0 +1,28 @@
+using Veritas.IP.Singapore;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class IpApplicationNumberTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[12];
+        IpApplicationNumber.TryGenerate(new GenerationOptions { Seed = 99 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        IpApplicationNumber.TryValidate(s, out var r);
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_Check()
+    {
+        Span<char> dst = stackalloc char[12];
+        IpApplicationNumber.TryGenerate(new GenerationOptions { Seed = 100 }, dst, out var w).ShouldBeTrue();
+        dst[11] = dst[11] == '0' ? '1' : '0';
+        var s = new string(dst[..w]);
+        IpApplicationNumber.TryValidate(s, out var r);
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/Identity/India/AadhaarTests.cs
+++ b/test/Veritas.Tests/Identity/India/AadhaarTests.cs
@@ -1,0 +1,25 @@
+using Veritas.Identity.India;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class AadhaarTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[12];
+        Aadhaar.TryGenerate(new GenerationOptions { Seed = 123 }, dst, out var written).ShouldBeTrue();
+        var s = new string(dst[..written]);
+        Aadhaar.TryValidate(s, out var r);
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("123412341235", false)]
+    public void Validate_Known(string input, bool expected)
+    {
+        Aadhaar.TryValidate(input, out var r);
+        r.IsValid.ShouldBe(expected);
+    }
+}

--- a/test/Veritas.Tests/Identity/Luxembourg/NationalIdTests.cs
+++ b/test/Veritas.Tests/Identity/Luxembourg/NationalIdTests.cs
@@ -1,0 +1,28 @@
+using Veritas.Identity.Luxembourg;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class NationalIdTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[13];
+        NationalId.TryGenerate(new GenerationOptions { Seed = 7 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        NationalId.TryValidate(s, out var r);
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_CheckDigits()
+    {
+        Span<char> dst = stackalloc char[13];
+        NationalId.TryGenerate(new GenerationOptions { Seed = 8 }, dst, out var w).ShouldBeTrue();
+        dst[11] = dst[11] == '0' ? '1' : '0';
+        var s = new string(dst[..w]);
+        NationalId.TryValidate(s, out var r);
+        r.IsValid.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- implement table-driven Verhoeff and Damm checksum algorithms
- add Aadhaar, SNOMED CT ID, Luxembourg National ID and Singapore IPOS application number validators/generators
- document new algorithms and identifiers in README and DocFX index

## Testing
- `dotnet test -f net8.0`

------
https://chatgpt.com/codex/tasks/task_e_68c48beedfec832b8a3bd7c25ca1773a