### PR TITLE
Align TryValidate semantics with .NET expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ Additional identifiers and algorithms will be added per the [PRD](prds/PRD.md).
 ## Example usage
 ```csharp
 // Validate an IBAN
-Finance.Iban.TryValidate("FR14 2004 1010 0505 0001 3M02 606", out var iban);
-Console.WriteLine(iban.IsValid);            // True
+var ok = Finance.Iban.TryValidate("FR14 2004 1010 0505 0001 3M02 606", out var iban);
+Console.WriteLine(ok);                      // True
 Console.WriteLine(iban.Value!.Value);       // FR1420041010050500013M02606
 
 // Generate a GTIN-13
@@ -191,8 +191,8 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 }
 
 // Validate a telecom identifier
-Telecom.Imei.TryValidate("490154203237518", out var imei);
-Console.WriteLine(imei.IsValid);            // True
+var imeiOk = Telecom.Imei.TryValidate("490154203237518", out var imei);
+Console.WriteLine(imeiOk);                  // True
 ```
 
 ## Contributing

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -25,8 +25,8 @@ dotnet add package Veritas --version 1.0.3
 
 ```csharp
 // Validate an IBAN
-Finance.Iban.TryValidate("FR14 2004 1010 0505 0001 3M02 606", out var iban);
-Console.WriteLine(iban.IsValid);            // True
+var ok = Finance.Iban.TryValidate("FR14 2004 1010 0505 0001 3M02 606", out var iban);
+Console.WriteLine(ok);                      // True
 
 // Generate an IMEI
 Telecom.Imei.TryGenerate(default, stackalloc char[15], out var written);

--- a/src/Veritas/Checksums/Verhoeff.cs
+++ b/src/Veritas/Checksums/Verhoeff.cs
@@ -29,7 +29,7 @@ public static class Verhoeff
         {7,0,4,6,9,1,3,2,5,8}
     };
 
-    private static readonly int[] inv = {0,4,3,2,1,5,6,7,8,9};
+    private static readonly int[] inv = { 0, 4, 3, 2, 1, 5, 6, 7, 8, 9 };
 
     /// <summary>Computes the Verhoeff check digit for the supplied numeric string.</summary>
     /// <param name="digits">Digits without the check digit.</param>

--- a/src/Veritas/Core/Algorithms/Mrz.cs
+++ b/src/Veritas/Core/Algorithms/Mrz.cs
@@ -5,7 +5,7 @@ namespace Veritas.Algorithms;
 /// <summary>Machine Readable Zone check digit calculator.</summary>
 internal static class Mrz
 {
-    private static readonly int[] Weights = {7,3,1};
+    private static readonly int[] Weights = { 7, 3, 1 };
 
     public static int Compute(ReadOnlySpan<char> input)
     {

--- a/src/Veritas/Core/Algorithms/VinMap.cs
+++ b/src/Veritas/Core/Algorithms/VinMap.cs
@@ -5,7 +5,7 @@ namespace Veritas.Algorithms;
 /// <summary>VIN transliteration and checksum helpers.</summary>
 internal static class VinMap
 {
-    private static readonly int[] Weights = {8,7,6,5,4,3,2,10,0,9,8,7,6,5,4,3,2};
+    private static readonly int[] Weights = { 8, 7, 6, 5, 4, 3, 2, 10, 0, 9, 8, 7, 6, 5, 4, 3, 2 };
 
     /// <summary>Validates a VIN string including its check digit.</summary>
     public static bool Validate(ReadOnlySpan<char> vin)

--- a/src/Veritas/Core/IValidator.cs
+++ b/src/Veritas/Core/IValidator.cs
@@ -8,6 +8,6 @@ public interface IValidator<T>
     /// <summary>Attempts to validate the provided input.</summary>
     /// <param name="input">The value to examine.</param>
     /// <param name="result">The validation result when the method returns.</param>
-    /// <returns><c>true</c> if the input could be processed; otherwise, <c>false</c>.</returns>
+    /// <returns><c>true</c> if the input is valid; otherwise, <c>false</c>.</returns>
     bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<T> result);
 }

--- a/src/Veritas/Education/Doi.cs
+++ b/src/Veritas/Education/Doi.cs
@@ -10,10 +10,10 @@ public static class Doi
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<DoiValue> result)
     {
         string s = new string(input).Trim();
-        if (!s.StartsWith("10.")) { result = new ValidationResult<DoiValue>(false, default, ValidationError.Format); return true; }
+        if (!s.StartsWith("10.")) { result = new ValidationResult<DoiValue>(false, default, ValidationError.Format); return false; }
         int slash = s.IndexOf('/');
-        if (slash <= 3 || slash == s.Length - 1) { result = new ValidationResult<DoiValue>(false, default, ValidationError.Format); return true; }
-        for (int i = 3; i < slash; i++) if (!char.IsDigit(s[i])) { result = new ValidationResult<DoiValue>(false, default, ValidationError.Charset); return true; }
+        if (slash <= 3 || slash == s.Length - 1) { result = new ValidationResult<DoiValue>(false, default, ValidationError.Format); return false; }
+        for (int i = 3; i < slash; i++) if (!char.IsDigit(s[i])) { result = new ValidationResult<DoiValue>(false, default, ValidationError.Charset); return false; }
         result = new ValidationResult<DoiValue>(true, new DoiValue(s), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Education/Ismn.cs
+++ b/src/Veritas/Education/Ismn.cs
@@ -22,14 +22,14 @@ public static class Ismn
         {
             if (ch == ' ' || ch == '-') continue;
             char up = char.ToUpperInvariant(ch);
-            if (len >= buf.Length) { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Length); return true; }
+            if (len >= buf.Length) { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Length); return false; }
             buf[len++] = up;
         }
         if (len == 10)
         {
-            if (buf[0] != 'M') { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Format); return true; }
+            if (buf[0] != 'M') { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Format); return false; }
             for (int i = 1; i < 10; i++)
-                if (buf[i] < '0' || buf[i] > '9') { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Charset); return true; }
+                if (buf[i] < '0' || buf[i] > '9') { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Charset); return false; }
             int sum = 3 * 3; // 'M' treated as 3
             for (int i = 1; i < 9; i++)
             {
@@ -37,22 +37,22 @@ public static class Ismn
                 sum += d * ((i % 2 == 1) ? 1 : 3);
             }
             int check = (10 - (sum % 10)) % 10;
-            if (buf[9] - '0' != check) { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Checksum); return true; }
+            if (buf[9] - '0' != check) { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Checksum); return false; }
             result = new ValidationResult<IsmnValue>(true, new IsmnValue(new string(buf[..10])), ValidationError.None);
             return true;
         }
         else if (len == 13)
         {
             for (int i = 0; i < 13; i++)
-                if (buf[i] < '0' || buf[i] > '9') { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Charset); return true; }
-            if (!Gs1.Validate(buf)) { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Checksum); return true; }
+                if (buf[i] < '0' || buf[i] > '9') { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Charset); return false; }
+            if (!Gs1.Validate(buf)) { result = new ValidationResult<IsmnValue>(false, default, ValidationError.Checksum); return false; }
             result = new ValidationResult<IsmnValue>(true, new IsmnValue(new string(buf)), ValidationError.None);
             return true;
         }
         else
         {
             result = new ValidationResult<IsmnValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
     }
 

--- a/src/Veritas/Education/Isni.cs
+++ b/src/Veritas/Education/Isni.cs
@@ -19,24 +19,24 @@ public static class Isni
             if (len >= 16)
             {
                 result = new ValidationResult<IsniValue>(false, default, ValidationError.Length);
-                return true;
+                return false;
             }
             if ((up < '0' || up > '9') && up != 'X')
             {
                 result = new ValidationResult<IsniValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
             buf[len++] = up;
         }
         if (len != 16)
         {
             result = new ValidationResult<IsniValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!Iso7064.ValidateMod11_2(buf))
         {
             result = new ValidationResult<IsniValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<IsniValue>(true, new IsniValue(new string(buf)), ValidationError.None);
         return true;

--- a/src/Veritas/Energy/DE/Malo.cs
+++ b/src/Veritas/Energy/DE/Malo.cs
@@ -20,14 +20,14 @@ public static class Malo
     /// <summary>Attempts to validate the supplied input as a MaLo identifier.</summary>
     /// <param name="input">Candidate identifier to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<MaloValue> result)
     {
         Span<char> digits = stackalloc char[11];
         if (!Normalize(input, digits, out int len) || len != 11)
         {
             result = new ValidationResult<MaloValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sumOdd = 0, sumEven = 0;
         for (int i = 0; i < 10; i++)
@@ -40,7 +40,7 @@ public static class Malo
         if (digits[10] != (char)('0' + check))
         {
             result = new ValidationResult<MaloValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<MaloValue>(true, new MaloValue(value), ValidationError.None);

--- a/src/Veritas/Energy/DE/Melo.cs
+++ b/src/Veritas/Energy/DE/Melo.cs
@@ -20,19 +20,19 @@ public static class Melo
     /// <summary>Attempts to validate the supplied input as a MeLo identifier.</summary>
     /// <param name="input">Candidate identifier to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<MeloValue> result)
     {
         Span<char> chars = stackalloc char[33];
         if (!Normalize(input, chars, out int len) || len != 33)
         {
             result = new ValidationResult<MeloValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (chars[0] != 'D' || chars[1] != 'E')
         {
             result = new ValidationResult<MeloValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         string value = new string(chars);
         result = new ValidationResult<MeloValue>(true, new MeloValue(value), ValidationError.None);

--- a/src/Veritas/Energy/DE/Zpn.cs
+++ b/src/Veritas/Energy/DE/Zpn.cs
@@ -20,19 +20,19 @@ public static class Zpn
     /// <summary>Attempts to validate the supplied input as a ZPN identifier.</summary>
     /// <param name="input">Candidate identifier to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<ZpnValue> result)
     {
         Span<char> chars = stackalloc char[33];
         if (!Normalize(input, chars, out int len) || len != 33)
         {
             result = new ValidationResult<ZpnValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (chars[0] != 'D' || chars[1] != 'E')
         {
             result = new ValidationResult<ZpnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         string value = new string(chars);
         result = new ValidationResult<ZpnValue>(true, new ZpnValue(value), ValidationError.None);

--- a/src/Veritas/Energy/ES/Cups.cs
+++ b/src/Veritas/Energy/ES/Cups.cs
@@ -22,31 +22,31 @@ public static class Cups
     /// <summary>Attempts to validate the supplied input as a CUPS identifier.</summary>
     /// <param name="input">Candidate identifier to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<CupsValue> result)
     {
         Span<char> buffer = stackalloc char[22];
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<CupsValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 20 && len != 22)
         {
             result = new ValidationResult<CupsValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (buffer[0] != 'E' || buffer[1] != 'S')
         {
             result = new ValidationResult<CupsValue>(false, default, ValidationError.CountryRule);
-            return true;
+            return false;
         }
         for (int i = 2; i < 18; i++)
         {
             if (!char.IsDigit(buffer[i]))
             {
                 result = new ValidationResult<CupsValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
         }
         if (len == 22)
@@ -54,12 +54,12 @@ public static class Cups
             if (!char.IsDigit(buffer[20]))
             {
                 result = new ValidationResult<CupsValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
             if ("FPRCXYZ".IndexOf(buffer[21]) < 0)
             {
                 result = new ValidationResult<CupsValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
         }
         int rem = 0;
@@ -70,7 +70,7 @@ public static class Cups
         if (buffer[18] != Alphabet[check0] || buffer[19] != Alphabet[check1])
         {
             result = new ValidationResult<CupsValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(buffer[..len]);
         result = new ValidationResult<CupsValue>(true, new CupsValue(value), ValidationError.None);

--- a/src/Veritas/Energy/Eic.cs
+++ b/src/Veritas/Energy/Eic.cs
@@ -21,19 +21,19 @@ public static class Eic
     /// <summary>Attempts to validate the supplied input as an EIC code.</summary>
     /// <param name="input">Candidate code to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<EicValue> result)
     {
         Span<char> buffer = stackalloc char[16];
         if (!Normalize(input, buffer, out int len) || len != 16)
         {
             result = new ValidationResult<EicValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!Iso7064.ValidateMod37_2(buffer))
         {
             result = new ValidationResult<EicValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(buffer);
         result = new ValidationResult<EicValue>(true, new EicValue(value), ValidationError.None);

--- a/src/Veritas/Energy/FR/Prm.cs
+++ b/src/Veritas/Energy/FR/Prm.cs
@@ -20,14 +20,14 @@ public static class Prm
     /// <summary>Attempts to validate the supplied input as a PRM identifier.</summary>
     /// <param name="input">Candidate identifier to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<PrmValue> result)
     {
         Span<char> digits = stackalloc char[14];
         if (!Normalize(input, digits, out int len) || len != 14)
         {
             result = new ValidationResult<PrmValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<PrmValue>(true, new PrmValue(value), ValidationError.None);

--- a/src/Veritas/Energy/GB/Mpan.cs
+++ b/src/Veritas/Energy/GB/Mpan.cs
@@ -22,19 +22,19 @@ public static class Mpan
     /// <summary>Attempts to validate the supplied input as an MPAN.</summary>
     /// <param name="input">Candidate identifier to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<MpanValue> result)
     {
         Span<char> digits = stackalloc char[13];
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<MpanValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 13)
         {
             result = new ValidationResult<MpanValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 12; i++)
@@ -44,7 +44,7 @@ public static class Mpan
         if (digits[12] - '0' != check)
         {
             result = new ValidationResult<MpanValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<MpanValue>(true, new MpanValue(value), ValidationError.None);

--- a/src/Veritas/Energy/GB/Mprn.cs
+++ b/src/Veritas/Energy/GB/Mprn.cs
@@ -20,19 +20,19 @@ public static class Mprn
     /// <summary>Attempts to validate the supplied input as an MPRN.</summary>
     /// <param name="input">Candidate identifier to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<MprnValue> result)
     {
         Span<char> digits = stackalloc char[10];
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<MprnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len < 6 || len > 10)
         {
             result = new ValidationResult<MprnValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         string value = new string(digits[..len]);
         result = new ValidationResult<MprnValue>(true, new MprnValue(value), ValidationError.None);

--- a/src/Veritas/Energy/IT/Pdr.cs
+++ b/src/Veritas/Energy/IT/Pdr.cs
@@ -20,19 +20,19 @@ public static class Pdr
     /// <summary>Attempts to validate the supplied input as a PDR identifier.</summary>
     /// <param name="input">Candidate identifier to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<PdrValue> result)
     {
         Span<char> digits = stackalloc char[14];
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<PdrValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 14)
         {
             result = new ValidationResult<PdrValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         result = new ValidationResult<PdrValue>(true, new PdrValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Energy/IT/Pod.cs
+++ b/src/Veritas/Energy/IT/Pod.cs
@@ -20,19 +20,19 @@ public static class Pod
     /// <summary>Attempts to validate the supplied input as a POD identifier.</summary>
     /// <param name="input">Candidate identifier to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<PodValue> result)
     {
         Span<char> chars = stackalloc char[16];
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<PodValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 16 || chars[0] != 'I' || chars[1] != 'T')
         {
             result = new ValidationResult<PodValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         result = new ValidationResult<PodValue>(true, new PodValue(new string(chars)), ValidationError.None);
         return true;

--- a/src/Veritas/Energy/NL/EnergyEan.cs
+++ b/src/Veritas/Energy/NL/EnergyEan.cs
@@ -21,24 +21,24 @@ public static class EnergyEan
     /// <summary>Attempts to validate the supplied input as an energy EAN code.</summary>
     /// <param name="input">Candidate code to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<EnergyEanValue> result)
     {
         Span<char> digits = stackalloc char[18];
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<EnergyEanValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 18)
         {
             result = new ValidationResult<EnergyEanValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!Gs1.Validate(digits))
         {
             result = new ValidationResult<EnergyEanValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<EnergyEanValue>(true, new EnergyEanValue(value), ValidationError.None);

--- a/src/Veritas/Finance/AbaRouting.cs
+++ b/src/Veritas/Finance/AbaRouting.cs
@@ -19,7 +19,7 @@ public static class AbaRouting
         if (!Normalize(input, buffer, out int len) || len != 9)
         {
             result = new ValidationResult<AbaRoutingValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 9; i++)
@@ -28,7 +28,7 @@ public static class AbaRouting
             if ((uint)d > 9)
             {
                 result = new ValidationResult<AbaRoutingValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
             int weight = i % 3 == 0 ? 3 : i % 3 == 1 ? 7 : 1;
             sum += d * weight;
@@ -36,7 +36,7 @@ public static class AbaRouting
         if (sum % 10 != 0)
         {
             result = new ValidationResult<AbaRoutingValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(buffer);
         result = new ValidationResult<AbaRoutingValue>(true, new AbaRoutingValue(value), ValidationError.None);

--- a/src/Veritas/Finance/Bic.cs
+++ b/src/Veritas/Finance/Bic.cs
@@ -19,12 +19,12 @@ public static class Bic
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<BicValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 8 && len != 11)
         {
             result = new ValidationResult<BicValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         for (int i = 0; i < 4; i++)
         {
@@ -32,7 +32,7 @@ public static class Bic
             if (c < 'A' || c > 'Z')
             {
                 result = new ValidationResult<BicValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
         }
         for (int i = 4; i < 6; i++)
@@ -41,7 +41,7 @@ public static class Bic
             if (c < 'A' || c > 'Z')
             {
                 result = new ValidationResult<BicValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
         }
         for (int i = 6; i < len; i++)
@@ -50,7 +50,7 @@ public static class Bic
             if (!char.IsLetterOrDigit(c))
             {
                 result = new ValidationResult<BicValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
         }
         string value = new string(buffer[..len]);

--- a/src/Veritas/Finance/Clabe.cs
+++ b/src/Veritas/Finance/Clabe.cs
@@ -11,7 +11,7 @@ public readonly struct ClabeValue
 
 public static class Clabe
 {
-    private static readonly int[] Weights = {3,7,1};
+    private static readonly int[] Weights = { 3, 7, 1 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<ClabeValue> result)
     {
@@ -19,7 +19,7 @@ public static class Clabe
         if (!Normalize(input, digits, out int len) || len != 18)
         {
             result = new ValidationResult<ClabeValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 17; i++)
@@ -31,7 +31,7 @@ public static class Clabe
         if (digits[17] != (char)('0' + check))
         {
             result = new ValidationResult<ClabeValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<ClabeValue>(true, new ClabeValue(value), ValidationError.None);

--- a/src/Veritas/Finance/Cusip.cs
+++ b/src/Veritas/Finance/Cusip.cs
@@ -17,18 +17,18 @@ public static class Cusip
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<CusipValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<CusipValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(chars[..8]);
         if (chars[8] - '0' != check)
         {
             result = new ValidationResult<CusipValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<CusipValue>(true, new CusipValue(new string(chars)), ValidationError.None);
         return true;

--- a/src/Veritas/Finance/Iban.cs
+++ b/src/Veritas/Finance/Iban.cs
@@ -20,12 +20,12 @@ public static class Iban
         if (!Normalize(input, normalized, out int len))
         {
             result = new ValidationResult<IbanValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len < 5)
         {
             result = new ValidationResult<IbanValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
 
         Span<char> digits = stackalloc char[68];
@@ -35,7 +35,7 @@ public static class Iban
         if (Iso7064.ComputeMod97(digits[..idx]) != 1)
         {
             result = new ValidationResult<IbanValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(normalized[..len]);
         result = new ValidationResult<IbanValue>(true, new IbanValue(value), ValidationError.None);

--- a/src/Veritas/Finance/Isin.cs
+++ b/src/Veritas/Finance/Isin.cs
@@ -20,7 +20,7 @@ public static class Isin
         if (!Normalize(input, buffer, out int len) || len != 12)
         {
             result = new ValidationResult<IsinValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         Span<char> digits = stackalloc char[24];
         int idx = 0;
@@ -41,7 +41,7 @@ public static class Isin
         if (!Luhn.Validate(digits[..idx]))
         {
             result = new ValidationResult<IsinValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(buffer[..len]);
         result = new ValidationResult<IsinValue>(true, new IsinValue(value), ValidationError.None);

--- a/src/Veritas/Finance/Lei.cs
+++ b/src/Veritas/Finance/Lei.cs
@@ -18,7 +18,7 @@ public static class Lei
         if (!Normalize(input, chars, out int len) || len != 20)
         {
             result = new ValidationResult<LeiValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         Span<char> digits = stackalloc char[40];
         int idx = 0;
@@ -27,7 +27,7 @@ public static class Lei
         if (Iso7064.ComputeMod97(digits[..idx]) != 1)
         {
             result = new ValidationResult<LeiValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(chars);
         result = new ValidationResult<LeiValue>(true, new LeiValue(value), ValidationError.None);

--- a/src/Veritas/Finance/Mic.cs
+++ b/src/Veritas/Finance/Mic.cs
@@ -17,12 +17,12 @@ public static class Mic
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<MicValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 4)
         {
             result = new ValidationResult<MicValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         result = new ValidationResult<MicValue>(true, new MicValue(new string(chars)), ValidationError.None);
         return true;

--- a/src/Veritas/Finance/Pan.cs
+++ b/src/Veritas/Finance/Pan.cs
@@ -20,17 +20,17 @@ public static class Pan
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<PanValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len < 12 || len > 19)
         {
             result = new ValidationResult<PanValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!Luhn.Validate(buffer[..len]))
         {
             result = new ValidationResult<PanValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(buffer[..len]);
         result = new ValidationResult<PanValue>(true, new PanValue(value), ValidationError.None);

--- a/src/Veritas/Finance/Rf.cs
+++ b/src/Veritas/Finance/Rf.cs
@@ -20,12 +20,12 @@ public static class Rf
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<RfValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len < 5 || len > 25 || buffer[0] != 'R' || buffer[1] != 'F')
         {
             result = new ValidationResult<RfValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         Span<char> digits = stackalloc char[50];
         int idx = 0;
@@ -34,7 +34,7 @@ public static class Rf
         if (Iso7064.ComputeMod97(digits[..idx]) != 1)
         {
             result = new ValidationResult<RfValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(buffer[..len]);
         result = new ValidationResult<RfValue>(true, new RfValue(value), ValidationError.None);

--- a/src/Veritas/Finance/Sedol.cs
+++ b/src/Veritas/Finance/Sedol.cs
@@ -11,7 +11,7 @@ public readonly struct SedolValue
 
 public static class Sedol
 {
-    private static readonly int[] Weights = {1,3,1,7,3,9,1};
+    private static readonly int[] Weights = { 1, 3, 1, 7, 3, 9, 1 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<SedolValue> result)
     {
@@ -19,25 +19,25 @@ public static class Sedol
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<SedolValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 7)
         {
             result = new ValidationResult<SedolValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 6; i++)
         {
             int v = ValueOf(chars[i]);
-            if (v < 0) { result = new ValidationResult<SedolValue>(false, default, ValidationError.Charset); return true; }
+            if (v < 0) { result = new ValidationResult<SedolValue>(false, default, ValidationError.Charset); return false; }
             sum += v * Weights[i];
         }
         int check = (10 - (sum % 10)) % 10;
         if (chars[6] - '0' != check)
         {
             result = new ValidationResult<SedolValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<SedolValue>(true, new SedolValue(new string(chars)), ValidationError.None);
         return true;

--- a/src/Veritas/Finance/Wkn.cs
+++ b/src/Veritas/Finance/Wkn.cs
@@ -17,12 +17,12 @@ public static class Wkn
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<WknValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 6)
         {
             result = new ValidationResult<WknValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         result = new ValidationResult<WknValue>(true, new WknValue(new string(chars)), ValidationError.None);
         return true;

--- a/src/Veritas/Healthcare/NhsNumber.cs
+++ b/src/Veritas/Healthcare/NhsNumber.cs
@@ -14,16 +14,16 @@ public static class NhsNumber
         foreach (var ch in input)
         {
             if (ch == ' ' || ch == '-') continue;
-            if (ch < '0' || ch > '9') { result = new ValidationResult<NhsNumberValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= 10) { result = new ValidationResult<NhsNumberValue>(false, default, ValidationError.Length); return true; }
+            if (ch < '0' || ch > '9') { result = new ValidationResult<NhsNumberValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 10) { result = new ValidationResult<NhsNumberValue>(false, default, ValidationError.Length); return false; }
             digits[len++] = ch;
         }
-        if (len != 10) { result = new ValidationResult<NhsNumberValue>(false, default, ValidationError.Length); return true; }
+        if (len != 10) { result = new ValidationResult<NhsNumberValue>(false, default, ValidationError.Length); return false; }
         int sum = 0;
         for (int i = 0; i < 9; i++) sum += (10 - i) * (digits[i] - '0');
         int check = 11 - (sum % 11);
         if (check == 11) check = 0;
-        if (check == 10 || check != digits[9] - '0') { result = new ValidationResult<NhsNumberValue>(false, default, ValidationError.Checksum); return true; }
+        if (check == 10 || check != digits[9] - '0') { result = new ValidationResult<NhsNumberValue>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<NhsNumberValue>(true, new NhsNumberValue(new string(digits)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Healthcare/Orcid.cs
+++ b/src/Veritas/Healthcare/Orcid.cs
@@ -16,12 +16,12 @@ public static class Orcid
         {
             if (ch == '-' || ch == ' ') continue;
             char u = char.ToUpperInvariant(ch);
-            if ((u < '0' || u > '9') && !(u == 'X' && len == 15)) { result = new ValidationResult<OrcidValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= 16) { result = new ValidationResult<OrcidValue>(false, default, ValidationError.Length); return true; }
+            if ((u < '0' || u > '9') && !(u == 'X' && len == 15)) { result = new ValidationResult<OrcidValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 16) { result = new ValidationResult<OrcidValue>(false, default, ValidationError.Length); return false; }
             digits[len++] = u;
         }
-        if (len != 16) { result = new ValidationResult<OrcidValue>(false, default, ValidationError.Length); return true; }
-        if (!Iso7064.ValidateMod11_2(digits)) { result = new ValidationResult<OrcidValue>(false, default, ValidationError.Checksum); return true; }
+        if (len != 16) { result = new ValidationResult<OrcidValue>(false, default, ValidationError.Length); return false; }
+        if (!Iso7064.ValidateMod11_2(digits)) { result = new ValidationResult<OrcidValue>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<OrcidValue>(true, new OrcidValue(new string(digits)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Healthcare/Snomed/SctId.cs
+++ b/src/Veritas/Healthcare/Snomed/SctId.cs
@@ -14,12 +14,12 @@ public static class SctId
         if (!Normalize(input, digits, out int len) || len < MinLength || len > MaxLength)
         {
             result = new ValidationResult<SctIdValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!Verhoeff.Validate(digits[..len]))
         {
             result = new ValidationResult<SctIdValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         var value = new string(digits[..len]);
         result = new ValidationResult<SctIdValue>(true, new SctIdValue(value), ValidationError.None);

--- a/src/Veritas/IP/Singapore/IpApplicationNumber.cs
+++ b/src/Veritas/IP/Singapore/IpApplicationNumber.cs
@@ -11,26 +11,26 @@ public static class IpApplicationNumber
         if (!Normalize(input, buf, out int len) || len != 12)
         {
             result = new ValidationResult<IpApplicationNumberValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!char.IsLetter(buf[0]) || !char.IsLetter(buf[1]))
         {
             result = new ValidationResult<IpApplicationNumberValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         for (int i = 2; i < 12; i++)
         {
             if (!char.IsDigit(buf[i]))
             {
                 result = new ValidationResult<IpApplicationNumberValue>(false, default, ValidationError.Format);
-                return true;
+                return false;
             }
         }
         byte check = Damm.Compute(buf.Slice(2, 9));
         if (buf[11] != (char)('0' + check))
         {
             result = new ValidationResult<IpApplicationNumberValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         var value = new string(buf);
         result = new ValidationResult<IpApplicationNumberValue>(true, new IpApplicationNumberValue(value), ValidationError.None);

--- a/src/Veritas/Identity/Base58Check.cs
+++ b/src/Veritas/Identity/Base58Check.cs
@@ -21,7 +21,7 @@ public static class Base58Check
             return true;
         }
         result = new ValidationResult<Base58CheckValue>(false, default, ValidationError.Format);
-        return true;
+        return false;
     }
 
     public static bool TryGenerate(Span<char> destination, out int written)

--- a/src/Veritas/Identity/Bcp47.cs
+++ b/src/Veritas/Identity/Bcp47.cs
@@ -19,7 +19,7 @@ public static class Bcp47
         if (input.IsEmpty)
         {
             result = new ValidationResult<Bcp47Value>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         Span<char> buf = stackalloc char[input.Length];
         for (int i = 0; i < input.Length; i++)
@@ -31,7 +31,7 @@ public static class Bcp47
             else
             {
                 result = new ValidationResult<Bcp47Value>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
         }
         var span = buf[..input.Length];
@@ -41,7 +41,7 @@ public static class Bcp47
             if (span.Length < 2 || span.Length > 8)
             {
                 result = new ValidationResult<Bcp47Value>(false, default, ValidationError.Format);
-                return true;
+                return false;
             }
         }
         else
@@ -51,12 +51,12 @@ public static class Bcp47
             if (lang.Length < 2 || lang.Length > 8 || region.Length != 2)
             {
                 result = new ValidationResult<Bcp47Value>(false, default, ValidationError.Format);
-                return true;
+                return false;
             }
             if (!(region[0] >= 'a' && region[0] <= 'z' && region[1] >= 'a' && region[1] <= 'z'))
             {
                 result = new ValidationResult<Bcp47Value>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
         }
         var tag = new string(span);
@@ -64,11 +64,12 @@ public static class Bcp47
         {
             CultureInfo.GetCultureInfo(tag);
             result = new ValidationResult<Bcp47Value>(true, new Bcp47Value(tag), ValidationError.None);
+            return true;
         }
         catch (CultureNotFoundException)
         {
             result = new ValidationResult<Bcp47Value>(false, default, ValidationError.Format);
+            return false;
         }
-        return true;
     }
 }

--- a/src/Veritas/Identity/Domain.cs
+++ b/src/Veritas/Identity/Domain.cs
@@ -13,11 +13,11 @@ public static class Domain
         int len = 0;
         foreach (var ch in input)
         {
-            if (ch == ' ') { result = new ValidationResult<DomainValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= buf.Length) { result = new ValidationResult<DomainValue>(false, default, ValidationError.Length); return true; }
+            if (ch == ' ') { result = new ValidationResult<DomainValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= buf.Length) { result = new ValidationResult<DomainValue>(false, default, ValidationError.Length); return false; }
             buf[len++] = char.ToLowerInvariant(ch);
         }
-        if (len == 0 || len > 253) { result = new ValidationResult<DomainValue>(false, default, ValidationError.Length); return true; }
+        if (len == 0 || len > 253) { result = new ValidationResult<DomainValue>(false, default, ValidationError.Length); return false; }
         int labelLen = 0;
         bool lastAlpha = false;
         for (int i = 0; i < len; i++)
@@ -25,7 +25,7 @@ public static class Domain
             char c = buf[i];
             if (c == '.')
             {
-                if (labelLen == 0 || labelLen > 63 || !lastAlpha) { result = new ValidationResult<DomainValue>(false, default, ValidationError.Format); return true; }
+                if (labelLen == 0 || labelLen > 63 || !lastAlpha) { result = new ValidationResult<DomainValue>(false, default, ValidationError.Format); return false; }
                 labelLen = 0; lastAlpha = false; continue;
             }
             if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || (c == '-' && labelLen > 0))
@@ -33,9 +33,9 @@ public static class Domain
                 lastAlpha = (c >= 'a' && c <= 'z');
                 labelLen++;
             }
-            else { result = new ValidationResult<DomainValue>(false, default, ValidationError.Charset); return true; }
+            else { result = new ValidationResult<DomainValue>(false, default, ValidationError.Charset); return false; }
         }
-        if (labelLen == 0 || labelLen > 63 || !lastAlpha) { result = new ValidationResult<DomainValue>(false, default, ValidationError.Format); return true; }
+        if (labelLen == 0 || labelLen > 63 || !lastAlpha) { result = new ValidationResult<DomainValue>(false, default, ValidationError.Format); return false; }
         result = new ValidationResult<DomainValue>(true, new DomainValue(new string(buf[..len])), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Identity/Email.cs
+++ b/src/Veritas/Identity/Email.cs
@@ -21,12 +21,13 @@ public static class Email
         {
             var addr = new MailAddress(str);
             result = new ValidationResult<EmailValue>(true, new EmailValue(addr.Address), ValidationError.None);
+            return true;
         }
         catch
         {
             result = new ValidationResult<EmailValue>(false, default, ValidationError.Format);
+            return false;
         }
-        return true;
     }
 }
 

--- a/src/Veritas/Identity/Ethereum.cs
+++ b/src/Veritas/Identity/Ethereum.cs
@@ -19,7 +19,7 @@ public static class Ethereum
         if (input.Length != 40)
         {
             result = new ValidationResult<EthereumValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         for (int i = 0; i < input.Length; i++)
         {
@@ -27,7 +27,7 @@ public static class Ethereum
             if (!Uri.IsHexDigit(c))
             {
                 result = new ValidationResult<EthereumValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
         }
         string value = "0x" + new string(input).ToLowerInvariant();

--- a/src/Veritas/Identity/India/Aadhaar.cs
+++ b/src/Veritas/Identity/India/Aadhaar.cs
@@ -12,7 +12,7 @@ public static class Aadhaar
         if (!Normalize(input, digits, out int len) || len != 12)
         {
             result = new ValidationResult<AadhaarValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         bool allSame = true;
         for (int i = 1; i < 12; i++)
@@ -20,12 +20,12 @@ public static class Aadhaar
         if (allSame)
         {
             result = new ValidationResult<AadhaarValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (!Verhoeff.Validate(digits))
         {
             result = new ValidationResult<AadhaarValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         var value = new string(digits);
         result = new ValidationResult<AadhaarValue>(true, new AadhaarValue(value), ValidationError.None);

--- a/src/Veritas/Identity/Israel/TeudatZehut.cs
+++ b/src/Veritas/Identity/Israel/TeudatZehut.cs
@@ -20,18 +20,18 @@ public static class TeudatZehut
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<TeudatZehutValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<TeudatZehutValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 9; i++)
         {
             int d = digits[i] - '0';
-            if ((uint)d > 9) { result = new ValidationResult<TeudatZehutValue>(false, default, ValidationError.Charset); return true; }
+            if ((uint)d > 9) { result = new ValidationResult<TeudatZehutValue>(false, default, ValidationError.Charset); return false; }
             int v = d * ((i % 2) + 1);
             if (v > 9) v -= 9;
             sum += v;
@@ -39,7 +39,7 @@ public static class TeudatZehut
         if (sum % 10 != 0)
         {
             result = new ValidationResult<TeudatZehutValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<TeudatZehutValue>(true, new TeudatZehutValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Identity/Ksuid.cs
+++ b/src/Veritas/Identity/Ksuid.cs
@@ -23,14 +23,14 @@ public static class Ksuid
         if (input.Length != 27)
         {
             result = new ValidationResult<KsuidValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         for (int i = 0; i < input.Length; i++)
         {
             if (Alphabet.IndexOf(input[i]) < 0)
             {
                 result = new ValidationResult<KsuidValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
         }
         result = new ValidationResult<KsuidValue>(true, new KsuidValue(new string(input)), ValidationError.None);

--- a/src/Veritas/Identity/Luxembourg/NationalId.cs
+++ b/src/Veritas/Identity/Luxembourg/NationalId.cs
@@ -12,19 +12,19 @@ public static class NationalId
         if (!Normalize(input, digits, out int len) || len != 13)
         {
             result = new ValidationResult<NationalIdValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         byte luhn = (byte)Luhn.ComputeCheckDigit(digits[..11]);
         if (digits[11] != (char)('0' + luhn))
         {
             result = new ValidationResult<NationalIdValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         byte ver = Verhoeff.Compute(digits[..11]);
         if (digits[12] != (char)('0' + ver))
         {
             result = new ValidationResult<NationalIdValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         var value = new string(digits);
         result = new ValidationResult<NationalIdValue>(true, new NationalIdValue(value), ValidationError.None);

--- a/src/Veritas/Identity/Mexico/Curp.cs
+++ b/src/Veritas/Identity/Mexico/Curp.cs
@@ -22,25 +22,25 @@ public static class Curp
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<CurpValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 18)
         {
             result = new ValidationResult<CurpValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 17; i++)
         {
             int v = Alphabet.IndexOf(chars[i]);
-            if (v < 0) { result = new ValidationResult<CurpValue>(false, default, ValidationError.Charset); return true; }
+            if (v < 0) { result = new ValidationResult<CurpValue>(false, default, ValidationError.Charset); return false; }
             sum += v * (18 - i);
         }
         int check = (10 - (sum % 10)) % 10;
         if (chars[17] - '0' != check)
         {
             result = new ValidationResult<CurpValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<CurpValue>(true, new CurpValue(new string(chars)), ValidationError.None);
         return true;

--- a/src/Veritas/Identity/NanoId.cs
+++ b/src/Veritas/Identity/NanoId.cs
@@ -15,11 +15,11 @@ public static class NanoId
         int len = 0;
         foreach (var ch in input)
         {
-            if (Alphabet.IndexOf(ch) < 0) { result = new ValidationResult<NanoIdValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= buf.Length) { result = new ValidationResult<NanoIdValue>(false, default, ValidationError.Length); return true; }
+            if (Alphabet.IndexOf(ch) < 0) { result = new ValidationResult<NanoIdValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= buf.Length) { result = new ValidationResult<NanoIdValue>(false, default, ValidationError.Length); return false; }
             buf[len++] = ch;
         }
-        if (len != 21) { result = new ValidationResult<NanoIdValue>(false, default, ValidationError.Length); return true; }
+        if (len != 21) { result = new ValidationResult<NanoIdValue>(false, default, ValidationError.Length); return false; }
         result = new ValidationResult<NanoIdValue>(true, new NanoIdValue(new string(buf[..len])), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Identity/Phone.cs
+++ b/src/Veritas/Identity/Phone.cs
@@ -15,11 +15,11 @@ public static class Phone
         {
             if (ch == ' ' || ch == '-') continue;
             if (len == 0 && ch == '+') { buf[len++] = ch; continue; }
-            if (ch < '0' || ch > '9') { result = new ValidationResult<PhoneValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= buf.Length) { result = new ValidationResult<PhoneValue>(false, default, ValidationError.Length); return true; }
+            if (ch < '0' || ch > '9') { result = new ValidationResult<PhoneValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= buf.Length) { result = new ValidationResult<PhoneValue>(false, default, ValidationError.Length); return false; }
             buf[len++] = ch;
         }
-        if (len < 4 || len > 16) { result = new ValidationResult<PhoneValue>(false, default, ValidationError.Length); return true; }
+        if (len < 4 || len > 16) { result = new ValidationResult<PhoneValue>(false, default, ValidationError.Length); return false; }
         result = new ValidationResult<PhoneValue>(true, new PhoneValue(new string(buf[..len])), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Identity/SouthAfrica/NationalId.cs
+++ b/src/Veritas/Identity/SouthAfrica/NationalId.cs
@@ -21,17 +21,17 @@ public static class NationalId
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<NationalIdValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 13)
         {
             result = new ValidationResult<NationalIdValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!Luhn.Validate(digits))
         {
             result = new ValidationResult<NationalIdValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<NationalIdValue>(true, new NationalIdValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Identity/Ulid.cs
+++ b/src/Veritas/Identity/Ulid.cs
@@ -17,11 +17,11 @@ public static class Ulid
         {
             if (ch == ' ' || ch == '-') continue;
             char u = char.ToUpperInvariant(ch);
-            if (Alphabet.IndexOf(u) < 0) { result = new ValidationResult<UlidValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= 26) { result = new ValidationResult<UlidValue>(false, default, ValidationError.Length); return true; }
+            if (Alphabet.IndexOf(u) < 0) { result = new ValidationResult<UlidValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 26) { result = new ValidationResult<UlidValue>(false, default, ValidationError.Length); return false; }
             buf[len++] = u;
         }
-        if (len != 26) { result = new ValidationResult<UlidValue>(false, default, ValidationError.Length); return true; }
+        if (len != 26) { result = new ValidationResult<UlidValue>(false, default, ValidationError.Length); return false; }
         result = new ValidationResult<UlidValue>(true, new UlidValue(new string(buf)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Logistics/Awb.cs
+++ b/src/Veritas/Logistics/Awb.cs
@@ -17,19 +17,19 @@ public static class Awb
             if ((uint)(ch - '0') > 9)
             {
                 result = new ValidationResult<AwbValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
             if (len >= 11)
             {
                 result = new ValidationResult<AwbValue>(false, default, ValidationError.Length);
-                return true;
+                return false;
             }
             digits[len++] = ch;
         }
         if (len != 11)
         {
             result = new ValidationResult<AwbValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int serial = 0;
         for (int i = 3; i < 10; i++)
@@ -38,7 +38,7 @@ public static class Awb
         if (digits[10] - '0' != check)
         {
             result = new ValidationResult<AwbValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<AwbValue>(true, new AwbValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Logistics/Gln.cs
+++ b/src/Veritas/Logistics/Gln.cs
@@ -15,12 +15,12 @@ public static class Gln
         foreach (var ch in input)
         {
             if (ch == ' ' || ch == '-') continue;
-            if (ch < '0' || ch > '9') { result = new ValidationResult<GlnValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= 13) { result = new ValidationResult<GlnValue>(false, default, ValidationError.Length); return true; }
+            if (ch < '0' || ch > '9') { result = new ValidationResult<GlnValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 13) { result = new ValidationResult<GlnValue>(false, default, ValidationError.Length); return false; }
             digits[len++] = ch;
         }
-        if (len != 13) { result = new ValidationResult<GlnValue>(false, default, ValidationError.Length); return true; }
-        if (!Gs1.Validate(digits)) { result = new ValidationResult<GlnValue>(false, default, ValidationError.Checksum); return true; }
+        if (len != 13) { result = new ValidationResult<GlnValue>(false, default, ValidationError.Length); return false; }
+        if (!Gs1.Validate(digits)) { result = new ValidationResult<GlnValue>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<GlnValue>(true, new GlnValue(new string(digits)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Logistics/Gtin.cs
+++ b/src/Veritas/Logistics/Gtin.cs
@@ -15,12 +15,12 @@ public static class Gtin
         foreach (var ch in input)
         {
             if (ch == ' ' || ch == '-') continue;
-            if (ch < '0' || ch > '9') { result = new ValidationResult<GtinValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= digits.Length) { result = new ValidationResult<GtinValue>(false, default, ValidationError.Length); return true; }
+            if (ch < '0' || ch > '9') { result = new ValidationResult<GtinValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= digits.Length) { result = new ValidationResult<GtinValue>(false, default, ValidationError.Length); return false; }
             digits[len++] = ch;
         }
-        if (!(len == 8 || len == 12 || len == 13 || len == 14)) { result = new ValidationResult<GtinValue>(false, default, ValidationError.Length); return true; }
-        if (!Gs1.Validate(digits[..len])) { result = new ValidationResult<GtinValue>(false, default, ValidationError.Checksum); return true; }
+        if (!(len == 8 || len == 12 || len == 13 || len == 14)) { result = new ValidationResult<GtinValue>(false, default, ValidationError.Length); return false; }
+        if (!Gs1.Validate(digits[..len])) { result = new ValidationResult<GtinValue>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<GtinValue>(true, new GtinValue(new string(digits[..len])), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Logistics/Imo.cs
+++ b/src/Veritas/Logistics/Imo.cs
@@ -21,19 +21,19 @@ public static class Imo
             if ((uint)(ch - '0') > 9)
             {
                 result = new ValidationResult<ImoValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
             if (len >= 7)
             {
                 result = new ValidationResult<ImoValue>(false, default, ValidationError.Length);
-                return true;
+                return false;
             }
             digits[len++] = ch;
         }
         if (len != 7)
         {
             result = new ValidationResult<ImoValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 6; i++)
@@ -42,7 +42,7 @@ public static class Imo
         if (digits[6] - '0' != check)
         {
             result = new ValidationResult<ImoValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         Span<char> norm = stackalloc char[10];
         norm[0] = 'I';

--- a/src/Veritas/Logistics/Iso6346.cs
+++ b/src/Veritas/Logistics/Iso6346.cs
@@ -15,11 +15,11 @@ public static class Iso6346
         foreach (var ch in input)
         {
             if (ch == ' ') continue;
-            if (len >= 11) { result = new ValidationResult<Iso6346Value>(false, default, ValidationError.Length); return true; }
+            if (len >= 11) { result = new ValidationResult<Iso6346Value>(false, default, ValidationError.Length); return false; }
             buf[len++] = char.ToUpperInvariant(ch);
         }
-        if (len != 11) { result = new ValidationResult<Iso6346Value>(false, default, ValidationError.Length); return true; }
-        if (!Iso6346Algorithm.Validate(buf)) { result = new ValidationResult<Iso6346Value>(false, default, ValidationError.Checksum); return true; }
+        if (len != 11) { result = new ValidationResult<Iso6346Value>(false, default, ValidationError.Length); return false; }
+        if (!Iso6346Algorithm.Validate(buf)) { result = new ValidationResult<Iso6346Value>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<Iso6346Value>(true, new Iso6346Value(new string(buf)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Logistics/Sscc.cs
+++ b/src/Veritas/Logistics/Sscc.cs
@@ -15,12 +15,12 @@ public static class Sscc
         foreach (var ch in input)
         {
             if (ch == ' ' || ch == '-') continue;
-            if (ch < '0' || ch > '9') { result = new ValidationResult<SsccValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= 18) { result = new ValidationResult<SsccValue>(false, default, ValidationError.Length); return true; }
+            if (ch < '0' || ch > '9') { result = new ValidationResult<SsccValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 18) { result = new ValidationResult<SsccValue>(false, default, ValidationError.Length); return false; }
             digits[len++] = ch;
         }
-        if (len != 18) { result = new ValidationResult<SsccValue>(false, default, ValidationError.Length); return true; }
-        if (!Gs1.Validate(digits)) { result = new ValidationResult<SsccValue>(false, default, ValidationError.Checksum); return true; }
+        if (len != 18) { result = new ValidationResult<SsccValue>(false, default, ValidationError.Length); return false; }
+        if (!Gs1.Validate(digits)) { result = new ValidationResult<SsccValue>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<SsccValue>(true, new SsccValue(new string(digits)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Logistics/Vin.cs
+++ b/src/Veritas/Logistics/Vin.cs
@@ -15,11 +15,11 @@ public static class Vin
         foreach (var ch in input)
         {
             if (ch == ' ' || ch == '-') continue;
-            if (len >= 17) { result = new ValidationResult<VinValue>(false, default, ValidationError.Length); return true; }
+            if (len >= 17) { result = new ValidationResult<VinValue>(false, default, ValidationError.Length); return false; }
             buf[len++] = ch;
         }
-        if (len != 17) { result = new ValidationResult<VinValue>(false, default, ValidationError.Length); return true; }
-        if (!VinMap.Validate(buf)) { result = new ValidationResult<VinValue>(false, default, ValidationError.Checksum); return true; }
+        if (len != 17) { result = new ValidationResult<VinValue>(false, default, ValidationError.Length); return false; }
+        if (!VinMap.Validate(buf)) { result = new ValidationResult<VinValue>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<VinValue>(true, new VinValue(new string(buf)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Media/Isbn10.cs
+++ b/src/Veritas/Media/Isbn10.cs
@@ -16,11 +16,11 @@ public static class Isbn10
         {
             if (ch == '-' || ch == ' ') continue;
             char u = char.ToUpperInvariant(ch);
-            if ((u < '0' || u > '9') && !(u == 'X' && len == 9)) { result = new ValidationResult<Isbn10Value>(false, default, ValidationError.Charset); return true; }
-            if (len >= 10) { result = new ValidationResult<Isbn10Value>(false, default, ValidationError.Length); return true; }
+            if ((u < '0' || u > '9') && !(u == 'X' && len == 9)) { result = new ValidationResult<Isbn10Value>(false, default, ValidationError.Charset); return false; }
+            if (len >= 10) { result = new ValidationResult<Isbn10Value>(false, default, ValidationError.Length); return false; }
             buf[len++] = u;
         }
-        if (len != 10) { result = new ValidationResult<Isbn10Value>(false, default, ValidationError.Length); return true; }
+        if (len != 10) { result = new ValidationResult<Isbn10Value>(false, default, ValidationError.Length); return false; }
         int sum = 0;
         for (int i = 0; i < 9; i++)
         {
@@ -28,7 +28,7 @@ public static class Isbn10
         }
         int check = 11 - (sum % 11);
         char expected = check == 10 ? 'X' : check == 11 ? '0' : (char)('0' + check);
-        if (buf[9] != expected) { result = new ValidationResult<Isbn10Value>(false, default, ValidationError.Checksum); return true; }
+        if (buf[9] != expected) { result = new ValidationResult<Isbn10Value>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<Isbn10Value>(true, new Isbn10Value(new string(buf)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Media/Isbn13.cs
+++ b/src/Veritas/Media/Isbn13.cs
@@ -15,12 +15,12 @@ public static class Isbn13
         foreach (var ch in input)
         {
             if (ch == '-' || ch == ' ') continue;
-            if (ch < '0' || ch > '9') { result = new ValidationResult<Isbn13Value>(false, default, ValidationError.Charset); return true; }
-            if (len >= 13) { result = new ValidationResult<Isbn13Value>(false, default, ValidationError.Length); return true; }
+            if (ch < '0' || ch > '9') { result = new ValidationResult<Isbn13Value>(false, default, ValidationError.Charset); return false; }
+            if (len >= 13) { result = new ValidationResult<Isbn13Value>(false, default, ValidationError.Length); return false; }
             digits[len++] = ch;
         }
-        if (len != 13) { result = new ValidationResult<Isbn13Value>(false, default, ValidationError.Length); return true; }
-        if (!Gs1.Validate(digits)) { result = new ValidationResult<Isbn13Value>(false, default, ValidationError.Checksum); return true; }
+        if (len != 13) { result = new ValidationResult<Isbn13Value>(false, default, ValidationError.Length); return false; }
+        if (!Gs1.Validate(digits)) { result = new ValidationResult<Isbn13Value>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<Isbn13Value>(true, new Isbn13Value(new string(digits)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Media/Isrc.cs
+++ b/src/Veritas/Media/Isrc.cs
@@ -21,20 +21,20 @@ public static class Isrc
         {
             if (ch == '-' || ch == ' ') continue;
             char up = char.ToUpperInvariant(ch);
-            if (len >= 12) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Length); return true; }
+            if (len >= 12) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Length); return false; }
             buf[len++] = up;
         }
-        if (len != 12) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Length); return true; }
+        if (len != 12) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Length); return false; }
         // CC
-        if (!IsLetter(buf[0]) || !IsLetter(buf[1])) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Charset); return true; }
+        if (!IsLetter(buf[0]) || !IsLetter(buf[1])) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Charset); return false; }
         // Registrant (alnum)
         for (int i = 2; i < 5; i++)
-            if (!IsAlnum(buf[i])) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Charset); return true; }
+            if (!IsAlnum(buf[i])) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Charset); return false; }
         // Year (digits)
-        if (!IsDigit(buf[5]) || !IsDigit(buf[6])) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Charset); return true; }
+        if (!IsDigit(buf[5]) || !IsDigit(buf[6])) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Charset); return false; }
         // Designation code (digits)
         for (int i = 7; i < 12; i++)
-            if (!IsDigit(buf[i])) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Charset); return true; }
+            if (!IsDigit(buf[i])) { result = new ValidationResult<IsrcValue>(false, default, ValidationError.Charset); return false; }
         result = new ValidationResult<IsrcValue>(true, new IsrcValue(new string(buf)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Media/Issn.cs
+++ b/src/Veritas/Media/Issn.cs
@@ -15,16 +15,16 @@ public static class Issn
         {
             if (ch == '-' || ch == ' ') continue;
             char u = char.ToUpperInvariant(ch);
-            if ((u < '0' || u > '9') && !(u == 'X' && len == 7)) { result = new ValidationResult<IssnValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= 8) { result = new ValidationResult<IssnValue>(false, default, ValidationError.Length); return true; }
+            if ((u < '0' || u > '9') && !(u == 'X' && len == 7)) { result = new ValidationResult<IssnValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 8) { result = new ValidationResult<IssnValue>(false, default, ValidationError.Length); return false; }
             buf[len++] = u;
         }
-        if (len != 8) { result = new ValidationResult<IssnValue>(false, default, ValidationError.Length); return true; }
+        if (len != 8) { result = new ValidationResult<IssnValue>(false, default, ValidationError.Length); return false; }
         int sum = 0;
         for (int i = 0; i < 7; i++) sum += (8 - i) * (buf[i] - '0');
         int check = 11 - (sum % 11);
         char expected = check == 10 ? 'X' : check == 11 ? '0' : (char)('0' + check);
-        if (buf[7] != expected) { result = new ValidationResult<IssnValue>(false, default, ValidationError.Checksum); return true; }
+        if (buf[7] != expected) { result = new ValidationResult<IssnValue>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<IssnValue>(true, new IssnValue(new string(buf)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Tax/AR/Cuit.cs
+++ b/src/Veritas/Tax/AR/Cuit.cs
@@ -22,18 +22,18 @@ public static class Cuit
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<CuitValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<CuitValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..10]);
         if (digits[10] - '0' != check)
         {
             result = new ValidationResult<CuitValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<CuitValue>(true, new CuitValue(value), ValidationError.None);

--- a/src/Veritas/Tax/AT/Uid.cs
+++ b/src/Veritas/Tax/AT/Uid.cs
@@ -14,7 +14,7 @@ public readonly struct UidValue
 /// </summary>
 public static class Uid
 {
-    private static readonly int[] Weights = {1,2,1,2,1,2,1};
+    private static readonly int[] Weights = { 1, 2, 1, 2, 1, 2, 1 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<UidValue> result)
     {
@@ -22,18 +22,18 @@ public static class Uid
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<UidValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 8)
         {
             result = new ValidationResult<UidValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..7]);
         if (digits[7] - '0' != check)
         {
             result = new ValidationResult<UidValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<UidValue>(true, new UidValue("ATU" + new string(digits)), ValidationError.None);
         return true;
@@ -50,42 +50,42 @@ public static class Uid
         destination[1] = 'T';
         destination[2] = 'U';
         var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
-        Span<char> digits = destination.Slice(3,8);
-        for (int i=0;i<7;i++)
-            digits[i] = (char)('0'+rng.Next(10));
-        digits[7] = (char)('0'+ComputeCheckDigit(digits[..7]));
+        Span<char> digits = destination.Slice(3, 8);
+        for (int i = 0; i < 7; i++)
+            digits[i] = (char)('0' + rng.Next(10));
+        digits[7] = (char)('0' + ComputeCheckDigit(digits[..7]));
         written = 11;
         return true;
     }
 
     private static int ComputeCheckDigit(ReadOnlySpan<char> digits)
     {
-        int sum=0;
-        for(int i=0;i<Weights.Length;i++)
+        int sum = 0;
+        for (int i = 0; i < Weights.Length; i++)
         {
-            int prod = (digits[i]-'0')*Weights[i];
-            sum += prod/10 + prod%10;
+            int prod = (digits[i] - '0') * Weights[i];
+            sum += prod / 10 + prod % 10;
         }
         sum += 4; // constant per spec
-        int check = 10 - (sum%10);
-        return check%10;
+        int check = 10 - (sum % 10);
+        return check % 10;
     }
 
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
     {
         len = 0;
         int i = 0;
-        if (input.Length >=3 && (input[0]=='A'||input[0]=='a') && (input[1]=='T'||input[1]=='t') && (input[2]=='U'||input[2]=='u'))
+        if (input.Length >= 3 && (input[0] == 'A' || input[0] == 'a') && (input[1] == 'T' || input[1] == 't') && (input[2] == 'U' || input[2] == 'u'))
             i = 3;
         for (; i < input.Length; i++)
         {
             char ch = input[i];
-            if (ch==' '||ch=='-') continue;
+            if (ch == ' ' || ch == '-') continue;
             if (!char.IsDigit(ch)) { len = 0; return false; }
-            if (len>=dest.Length){ len=0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
             dest[len++] = ch;
         }
-        return len>0;
+        return len > 0;
     }
 }
 

--- a/src/Veritas/Tax/AU/Abn.cs
+++ b/src/Veritas/Tax/AU/Abn.cs
@@ -11,7 +11,7 @@ public readonly struct AbnValue
 
 public static class Abn
 {
-    private static readonly int[] Weights = {10,1,3,5,7,9,11,13,15,17,19};
+    private static readonly int[] Weights = { 10, 1, 3, 5, 7, 9, 11, 13, 15, 17, 19 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<AbnValue> result)
     {
@@ -19,12 +19,12 @@ public static class Abn
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<AbnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<AbnValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = (digits[0] - '1') * Weights[0];
         for (int i = 1; i < 11; i++)
@@ -32,7 +32,7 @@ public static class Abn
         if (sum % 89 != 0)
         {
             result = new ValidationResult<AbnValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<AbnValue>(true, new AbnValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/AU/Tfn.cs
+++ b/src/Veritas/Tax/AU/Tfn.cs
@@ -11,8 +11,8 @@ public readonly struct TfnValue
 
 public static class Tfn
 {
-    private static readonly int[] Weights8 = {1,4,3,7,5,8,6,9};
-    private static readonly int[] Weights9 = {1,4,3,7,5,8,6,9,10};
+    private static readonly int[] Weights8 = { 1, 4, 3, 7, 5, 8, 6, 9 };
+    private static readonly int[] Weights9 = { 1, 4, 3, 7, 5, 8, 6, 9, 10 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<TfnValue> result)
     {
@@ -20,12 +20,12 @@ public static class Tfn
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<TfnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 8 && len != 9)
         {
             result = new ValidationResult<TfnValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         var weights = len == 8 ? Weights8 : Weights9;
         int sum = 0;
@@ -34,7 +34,7 @@ public static class Tfn
         if (sum % 11 != 0)
         {
             result = new ValidationResult<TfnValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<TfnValue>(true, new TfnValue(new string(digits[..len])), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/BE/Nn.cs
+++ b/src/Veritas/Tax/BE/Nn.cs
@@ -20,19 +20,19 @@ public static class Nn
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<NnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<NnValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         long baseNumber = ParseLong(digits[..9]);
         int check = (digits[9] - '0') * 10 + (digits[10] - '0');
         if (!Verify(baseNumber, check))
         {
             result = new ValidationResult<NnValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<NnValue>(true, new NnValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/BG/Egn.cs
+++ b/src/Veritas/Tax/BG/Egn.cs
@@ -22,18 +22,18 @@ public static class Egn
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<EgnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 10)
         {
             result = new ValidationResult<EgnValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..9]);
         if (digits[9] - '0' != check)
         {
             result = new ValidationResult<EgnValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<EgnValue>(true, new EgnValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/BR/Cnpj.cs
+++ b/src/Veritas/Tax/BR/Cnpj.cs
@@ -20,33 +20,33 @@ public static class Cnpj
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<CnpjValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 14)
         {
             result = new ValidationResult<CnpjValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (AllEqual(digits))
         {
             result = new ValidationResult<CnpjValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         int d1 = ComputeCheckDigit(digits[..12], Weights1);
         if (digits[12] - '0' != d1)
         {
             result = new ValidationResult<CnpjValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         int d2 = ComputeCheckDigit(digits[..13], Weights2);
         if (digits[13] - '0' != d2)
         {
             result = new ValidationResult<CnpjValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(digits);
-       result = new ValidationResult<CnpjValue>(true, new CnpjValue(value), ValidationError.None);
-       return true;
+        result = new ValidationResult<CnpjValue>(true, new CnpjValue(value), ValidationError.None);
+        return true;
     }
 
     public static bool TryGenerate(Span<char> destination, out int written)

--- a/src/Veritas/Tax/BR/Cpf.cs
+++ b/src/Veritas/Tax/BR/Cpf.cs
@@ -20,29 +20,29 @@ public static class Cpf
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<CpfValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<CpfValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (AllEqual(digits))
         {
             result = new ValidationResult<CpfValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         int d1 = ComputeCheckDigit(digits[..9], Weights1);
         if (digits[9] - '0' != d1)
         {
             result = new ValidationResult<CpfValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         int d2 = ComputeCheckDigit(digits[..10], Weights2);
         if (digits[10] - '0' != d2)
         {
             result = new ValidationResult<CpfValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<CpfValue>(true, new CpfValue(value), ValidationError.None);

--- a/src/Veritas/Tax/CA/Bn.cs
+++ b/src/Veritas/Tax/CA/Bn.cs
@@ -18,17 +18,17 @@ public static class Bn
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<BnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<BnValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!Luhn.Validate(digits))
         {
             result = new ValidationResult<BnValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<BnValue>(true, new BnValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/CA/Sin.cs
+++ b/src/Veritas/Tax/CA/Sin.cs
@@ -18,17 +18,17 @@ public static class Sin
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<SinValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<SinValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!Luhn.Validate(digits))
         {
             result = new ValidationResult<SinValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<SinValue>(true, new SinValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/CH/Ahv.cs
+++ b/src/Veritas/Tax/CH/Ahv.cs
@@ -22,17 +22,17 @@ public static class Ahv
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<AhvValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 13)
         {
             result = new ValidationResult<AhvValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!Iso7064.ValidateMod11_10(digits))
         {
             result = new ValidationResult<AhvValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<AhvValue>(true, new AhvValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/CH/Uid.cs
+++ b/src/Veritas/Tax/CH/Uid.cs
@@ -20,18 +20,18 @@ public static class Uid
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<UidValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<UidValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..8]);
         if (digits[8] - '0' != check)
         {
             result = new ValidationResult<UidValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<UidValue>(true, new UidValue("CHE" + new string(digits)), ValidationError.None);
         return true;
@@ -75,7 +75,7 @@ public static class Uid
         bool prefixSeen = false;
         int i = 0;
         while (i < input.Length && char.IsWhiteSpace(input[i])) i++;
-        if (i + 3 <= input.Length && (input[i] == 'C' || input[i] == 'c') && (input[i+1]=='H' || input[i+1]=='h') && (input[i+2]=='E'||input[i+2]=='e'))
+        if (i + 3 <= input.Length && (input[i] == 'C' || input[i] == 'c') && (input[i + 1] == 'H' || input[i + 1] == 'h') && (input[i + 2] == 'E' || input[i + 2] == 'e'))
         {
             prefixSeen = true;
             i += 3;

--- a/src/Veritas/Tax/CL/Rut.cs
+++ b/src/Veritas/Tax/CL/Rut.cs
@@ -20,18 +20,18 @@ public static class Rut
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<RutValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len < 2 || len > 9)
         {
             result = new ValidationResult<RutValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         char expected = ComputeCheckChar(buffer[..(len - 1)]);
         if (buffer[len - 1] != expected)
         {
             result = new ValidationResult<RutValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(buffer[..len]);
         result = new ValidationResult<RutValue>(true, new RutValue(value), ValidationError.None);

--- a/src/Veritas/Tax/CN/Uscc.cs
+++ b/src/Veritas/Tax/CN/Uscc.cs
@@ -12,7 +12,7 @@ public readonly struct UsccValue
 public static class Uscc
 {
     private const string Alphabet = "0123456789ABCDEFGHJKLMNPQRTUWXY";
-    private static readonly int[] Weights = {1,3,9,27,19,26,16,17,20,29,25,13,8,24,10,30,28};
+    private static readonly int[] Weights = { 1, 3, 9, 27, 19, 26, 16, 17, 20, 29, 25, 13, 8, 24, 10, 30, 28 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<UsccValue> result)
     {
@@ -20,18 +20,18 @@ public static class Uscc
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<UsccValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 18)
         {
             result = new ValidationResult<UsccValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 17; i++)
         {
             int v = Alphabet.IndexOf(chars[i]);
-            if (v < 0) { result = new ValidationResult<UsccValue>(false, default, ValidationError.Charset); return true; }
+            if (v < 0) { result = new ValidationResult<UsccValue>(false, default, ValidationError.Charset); return false; }
             sum += v * Weights[i];
         }
         int check = (31 - (sum % 31)) % 31;
@@ -39,7 +39,7 @@ public static class Uscc
         if (chars[17] != expected)
         {
             result = new ValidationResult<UsccValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<UsccValue>(true, new UsccValue(new string(chars)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/CO/Nit.cs
+++ b/src/Veritas/Tax/CO/Nit.cs
@@ -14,7 +14,7 @@ public readonly struct NitValue
 /// </summary>
 public static class Nit
 {
-    private static readonly int[] Weights = {3,7,13,17,19,23,29,37,41,43,47};
+    private static readonly int[] Weights = { 3, 7, 13, 17, 19, 23, 29, 37, 41, 43, 47 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<NitValue> result)
     {
@@ -22,18 +22,18 @@ public static class Nit
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<NitValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len < 2 || len > 10)
         {
             result = new ValidationResult<NitValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
-        int check = ComputeCheckDigit(digits[..(len-1)]);
-        if (digits[len-1]-'0' != check)
+        int check = ComputeCheckDigit(digits[..(len - 1)]);
+        if (digits[len - 1] - '0' != check)
         {
             result = new ValidationResult<NitValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<NitValue>(true, new NitValue(new string(digits[..len])), ValidationError.None);
         return true;
@@ -44,14 +44,14 @@ public static class Nit
 
     public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
     {
-        written=0;
-        if (destination.Length<10) return false;
+        written = 0;
+        if (destination.Length < 10) return false;
         var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
-        int len = rng.Next(2,10); // including check
+        int len = rng.Next(2, 10); // including check
         Span<char> digits = destination[..len];
-        for(int i=0;i<len-1;i++) digits[i]=(char)('0'+rng.Next(10));
-        digits[len-1]=(char)('0'+ComputeCheckDigit(digits[..(len-1)]));
-        written=len;
+        for (int i = 0; i < len - 1; i++) digits[i] = (char)('0' + rng.Next(10));
+        digits[len - 1] = (char)('0' + ComputeCheckDigit(digits[..(len - 1)]));
+        written = len;
         return true;
     }
 
@@ -67,13 +67,13 @@ public static class Nit
 
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
     {
-        len=0;
-        foreach(var ch in input)
+        len = 0;
+        foreach (var ch in input)
         {
-            if (ch=='-'||ch==' ') continue;
-            if(!char.IsDigit(ch)){ len=0; return false; }
-            if(len>=dest.Length){ len=0; return false; }
-            dest[len++]=ch;
+            if (ch == '-' || ch == ' ') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
         }
         return true;
     }

--- a/src/Veritas/Tax/CZ/RodneCislo.cs
+++ b/src/Veritas/Tax/CZ/RodneCislo.cs
@@ -20,19 +20,19 @@ public static class RodneCislo
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<RodneCisloValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9 && len != 10)
         {
             result = new ValidationResult<RodneCisloValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (len == 9)
         {
             if (ParseLong(digits[..9]) % 11 != 0)
             {
                 result = new ValidationResult<RodneCisloValue>(false, default, ValidationError.Checksum);
-                return true;
+                return false;
             }
         }
         else
@@ -43,7 +43,7 @@ public static class RodneCislo
             if (check != digits[9] - '0')
             {
                 result = new ValidationResult<RodneCisloValue>(false, default, ValidationError.Checksum);
-                return true;
+                return false;
             }
         }
         result = new ValidationResult<RodneCisloValue>(true, new RodneCisloValue(new string(digits[..len])), ValidationError.None);
@@ -84,7 +84,7 @@ public static class RodneCislo
     private static long ParseLong(ReadOnlySpan<char> digits)
     {
         long n = 0;
-        foreach (var ch in digits) n = n*10 + (ch - '0');
+        foreach (var ch in digits) n = n * 10 + (ch - '0');
         return n;
     }
 

--- a/src/Veritas/Tax/DE/IdNr.cs
+++ b/src/Veritas/Tax/DE/IdNr.cs
@@ -18,17 +18,17 @@ public static class IdNr
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<IdNrValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<IdNrValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (digits[0] == '0')
         {
             result = new ValidationResult<IdNrValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         Span<int> counts = stackalloc int[10];
         for (int i = 0; i < 10; i++)
@@ -45,12 +45,12 @@ public static class IdNr
         if (!(repeatGroups == 1 && (repeatCount == 2 || repeatCount == 3)))
         {
             result = new ValidationResult<IdNrValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (!Iso7064.ValidateMod11_10(digits))
         {
             result = new ValidationResult<IdNrValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<IdNrValue>(true, new IdNrValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/DE/UstIdNr.cs
+++ b/src/Veritas/Tax/DE/UstIdNr.cs
@@ -18,23 +18,23 @@ public static class UstIdNr
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<UstIdNrValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<UstIdNrValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (digits[0] == '0')
         {
             result = new ValidationResult<UstIdNrValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         char check = Iso7064.ComputeCheckDigitMod11_10(digits[..8]);
         if (digits[8] != check)
         {
             result = new ValidationResult<UstIdNrValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<UstIdNrValue>(true, new UstIdNrValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/DK/Cpr.cs
+++ b/src/Veritas/Tax/DK/Cpr.cs
@@ -20,17 +20,17 @@ public static class Cpr
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<CprValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 10)
         {
             result = new ValidationResult<CprValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!DateTime.TryParseExact(new string(digits[..6]), "ddMMyy", null, System.Globalization.DateTimeStyles.None, out _))
         {
             result = new ValidationResult<CprValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         result = new ValidationResult<CprValue>(true, new CprValue(new string(digits)), ValidationError.None);
         return true;
@@ -41,33 +41,33 @@ public static class Cpr
 
     public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
     {
-        written=0;
-        if (destination.Length<10) return false;
+        written = 0;
+        if (destination.Length < 10) return false;
         var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
         Span<char> digits = destination[..10];
-        int year=rng.Next(1900,2100);
-        int month=rng.Next(1,13);
-        int day=rng.Next(1, DateTime.DaysInMonth(year,month)+1);
-        digits[0]=(char)('0'+(day/10));
-        digits[1]=(char)('0'+(day%10));
-        digits[2]=(char)('0'+(month/10));
-        digits[3]=(char)('0'+(month%10));
-        digits[4]=(char)('0'+(year%100/10));
-        digits[5]=(char)('0'+(year%10));
-        for(int i=6;i<10;i++) digits[i]=(char)('0'+rng.Next(10));
-        written=10;
+        int year = rng.Next(1900, 2100);
+        int month = rng.Next(1, 13);
+        int day = rng.Next(1, DateTime.DaysInMonth(year, month) + 1);
+        digits[0] = (char)('0' + (day / 10));
+        digits[1] = (char)('0' + (day % 10));
+        digits[2] = (char)('0' + (month / 10));
+        digits[3] = (char)('0' + (month % 10));
+        digits[4] = (char)('0' + (year % 100 / 10));
+        digits[5] = (char)('0' + (year % 10));
+        for (int i = 6; i < 10; i++) digits[i] = (char)('0' + rng.Next(10));
+        written = 10;
         return true;
     }
 
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
     {
-        len=0;
-        foreach(var ch in input)
+        len = 0;
+        foreach (var ch in input)
         {
-            if (ch=='-'||ch==' ') continue;
-            if(!char.IsDigit(ch)){ len=0; return false; }
-            if(len>=dest.Length){ len=0; return false; }
-            dest[len++]=ch;
+            if (ch == '-' || ch == ' ') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
         }
         return true;
     }

--- a/src/Veritas/Tax/EE/Isikukood.cs
+++ b/src/Veritas/Tax/EE/Isikukood.cs
@@ -14,8 +14,8 @@ public readonly struct IsikukoodValue
 /// </summary>
 public static class Isikukood
 {
-    private static readonly int[] Weights1 = {1,2,3,4,5,6,7,8,9,1};
-    private static readonly int[] Weights2 = {3,4,5,6,7,8,9,1,2,3};
+    private static readonly int[] Weights1 = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 1 };
+    private static readonly int[] Weights2 = { 3, 4, 5, 6, 7, 8, 9, 1, 2, 3 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<IsikukoodValue> result)
     {
@@ -23,18 +23,18 @@ public static class Isikukood
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<IsikukoodValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<IsikukoodValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..10]);
-        if (digits[10]-'0' != check)
+        if (digits[10] - '0' != check)
         {
             result = new ValidationResult<IsikukoodValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<IsikukoodValue>(true, new IsikukoodValue(new string(digits)), ValidationError.None);
         return true;
@@ -45,48 +45,48 @@ public static class Isikukood
 
     public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
     {
-        written=0;
-        if (destination.Length<11) return false;
+        written = 0;
+        if (destination.Length < 11) return false;
         var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
         Span<char> digits = destination[..11];
-        int year=rng.Next(1900,2100);
-        int month=rng.Next(1,13);
-        int day=rng.Next(1, DateTime.DaysInMonth(year,month)+1);
-        int s = year>=2000? (rng.Next(2)==0?5:6) : (rng.Next(2)==0?3:4);
-        digits[0]=(char)('0'+s);
-        digits[1]=(char)('0'+(year%100/10));
-        digits[2]=(char)('0'+(year%10));
-        digits[3]=(char)('0'+(month/10));
-        digits[4]=(char)('0'+(month%10));
-        digits[5]=(char)('0'+(day/10));
-        digits[6]=(char)('0'+(day%10));
-        for(int i=7;i<10;i++) digits[i]=(char)('0'+rng.Next(10));
-        digits[10]=(char)('0'+ComputeCheckDigit(digits[..10]));
-        written=11;
+        int year = rng.Next(1900, 2100);
+        int month = rng.Next(1, 13);
+        int day = rng.Next(1, DateTime.DaysInMonth(year, month) + 1);
+        int s = year >= 2000 ? (rng.Next(2) == 0 ? 5 : 6) : (rng.Next(2) == 0 ? 3 : 4);
+        digits[0] = (char)('0' + s);
+        digits[1] = (char)('0' + (year % 100 / 10));
+        digits[2] = (char)('0' + (year % 10));
+        digits[3] = (char)('0' + (month / 10));
+        digits[4] = (char)('0' + (month % 10));
+        digits[5] = (char)('0' + (day / 10));
+        digits[6] = (char)('0' + (day % 10));
+        for (int i = 7; i < 10; i++) digits[i] = (char)('0' + rng.Next(10));
+        digits[10] = (char)('0' + ComputeCheckDigit(digits[..10]));
+        written = 11;
         return true;
     }
 
     private static int ComputeCheckDigit(ReadOnlySpan<char> digits)
     {
-        int sum=0;
-        for(int i=0;i<Weights1.Length;i++) sum += (digits[i]-'0')*Weights1[i];
-        int r=sum%11;
-        if (r<10) return r;
-        sum=0;
-        for(int i=0;i<Weights2.Length;i++) sum += (digits[i]-'0')*Weights2[i];
-        r=sum%11;
-        return r<10? r : 0;
+        int sum = 0;
+        for (int i = 0; i < Weights1.Length; i++) sum += (digits[i] - '0') * Weights1[i];
+        int r = sum % 11;
+        if (r < 10) return r;
+        sum = 0;
+        for (int i = 0; i < Weights2.Length; i++) sum += (digits[i] - '0') * Weights2[i];
+        r = sum % 11;
+        return r < 10 ? r : 0;
     }
 
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
     {
-        len=0;
-        foreach(var ch in input)
+        len = 0;
+        foreach (var ch in input)
         {
-            if (ch=='-'||ch==' ') continue;
-            if(!char.IsDigit(ch)){ len=0; return false; }
-            if(len>=dest.Length){ len=0; return false; }
-            dest[len++]=ch;
+            if (ch == '-' || ch == ' ') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
         }
         return true;
     }

--- a/src/Veritas/Tax/ES/Cif.cs
+++ b/src/Veritas/Tax/ES/Cif.cs
@@ -19,12 +19,12 @@ public static class Cif
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<CifValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<CifValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         char first = buffer[0];
         int sum = 0;
@@ -54,7 +54,7 @@ public static class Cif
         if (!ok)
         {
             result = new ValidationResult<CifValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<CifValue>(true, new CifValue(new string(buffer)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/ES/Nie.cs
+++ b/src/Veritas/Tax/ES/Nie.cs
@@ -19,18 +19,18 @@ public static class Nie
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<NieValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<NieValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         char first = buffer[0];
         if (first != 'X' && first != 'Y' && first != 'Z')
         {
             result = new ValidationResult<NieValue>(false, default, ValidationError.CountryRule);
-            return true;
+            return false;
         }
         int number = first == 'X' ? 0 : first == 'Y' ? 1 : 2;
         for (int i = 1; i < 8; i++)
@@ -41,7 +41,7 @@ public static class Nie
         if (buffer[8] != expected)
         {
             result = new ValidationResult<NieValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<NieValue>(true, new NieValue(new string(buffer)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/ES/Nif.cs
+++ b/src/Veritas/Tax/ES/Nif.cs
@@ -19,12 +19,12 @@ public static class Nif
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<NifValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<NifValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int number = 0;
         for (int i = 0; i < 8; i++)
@@ -35,7 +35,7 @@ public static class Nif
         if (buffer[8] != expected)
         {
             result = new ValidationResult<NifValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<NifValue>(true, new NifValue(new string(buffer)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/FI/Hetu.cs
+++ b/src/Veritas/Tax/FI/Hetu.cs
@@ -22,36 +22,36 @@ public static class Hetu
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<HetuValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<HetuValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         char sep = buffer[6];
         if (sep != '+' && sep != '-' && sep != 'A')
         {
             result = new ValidationResult<HetuValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         for (int i = 0; i < 6; i++)
             if (!char.IsDigit(buffer[i]))
             {
                 result = new ValidationResult<HetuValue>(false, default, ValidationError.Format);
-                return true;
+                return false;
             }
         for (int i = 7; i < 10; i++)
             if (!char.IsDigit(buffer[i]))
             {
                 result = new ValidationResult<HetuValue>(false, default, ValidationError.Format);
-                return true;
+                return false;
             }
         char check = char.ToUpperInvariant(buffer[10]);
         if (!CheckMap.Contains(check))
         {
             result = new ValidationResult<HetuValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         int number = 0;
         for (int i = 0; i < 6; i++)
@@ -62,7 +62,7 @@ public static class Hetu
         if (check != expected)
         {
             result = new ValidationResult<HetuValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<HetuValue>(true, new HetuValue(new string(buffer)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/FR/Siren.cs
+++ b/src/Veritas/Tax/FR/Siren.cs
@@ -18,17 +18,17 @@ public static class Siren
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<SirenValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<SirenValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!Luhn.Validate(digits))
         {
             result = new ValidationResult<SirenValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<SirenValue>(true, new SirenValue(value), ValidationError.None);

--- a/src/Veritas/Tax/FR/Siret.cs
+++ b/src/Veritas/Tax/FR/Siret.cs
@@ -18,12 +18,12 @@ public static class Siret
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<SiretValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 14)
         {
             result = new ValidationResult<SiretValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         ReadOnlySpan<char> laPoste = "356000000";
         bool special = digits[..9].SequenceEqual(laPoste) && !digits.SequenceEqual("35600000000048");
@@ -34,18 +34,18 @@ public static class Siret
             if (sum % 5 != 0)
             {
                 result = new ValidationResult<SiretValue>(false, default, ValidationError.Checksum);
-                return true;
+                return false;
             }
         }
         else if (!Luhn.Validate(digits))
         {
             result = new ValidationResult<SiretValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         if (!Siren.TryValidate(digits[..9], out var sr) || !sr.IsValid)
         {
             result = new ValidationResult<SiretValue>(false, default, ValidationError.CountryRule);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<SiretValue>(true, new SiretValue(value), ValidationError.None);

--- a/src/Veritas/Tax/FR/Vat.cs
+++ b/src/Veritas/Tax/FR/Vat.cs
@@ -17,12 +17,12 @@ public static class Vat
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<VatValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<VatValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         // first two digits are the checksum key
         int key = (digits[0] - '0') * 10 + (digits[1] - '0');
@@ -35,7 +35,7 @@ public static class Vat
         if (key != expected)
         {
             result = new ValidationResult<VatValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<VatValue>(true, new VatValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/GR/Afm.cs
+++ b/src/Veritas/Tax/GR/Afm.cs
@@ -20,12 +20,12 @@ public static class Afm
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<AfmValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<AfmValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 8; i++)
@@ -34,7 +34,7 @@ public static class Afm
         if (digits[8] - '0' != expected)
         {
             result = new ValidationResult<AfmValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<AfmValue>(true, new AfmValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/HR/Oib.cs
+++ b/src/Veritas/Tax/HR/Oib.cs
@@ -20,18 +20,18 @@ public static class Oib
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<OibValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<OibValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = digits[10] - '0';
         if (ComputeCheck(digits[..10]) != check)
         {
             result = new ValidationResult<OibValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<OibValue>(true, new OibValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/IE/Ppsn.cs
+++ b/src/Veritas/Tax/IE/Ppsn.cs
@@ -22,30 +22,30 @@ public static class Ppsn
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<PpsnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 8 && len != 9)
         {
             result = new ValidationResult<PpsnValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         for (int i = 0; i < 7; i++)
             if (!char.IsDigit(buffer[i]))
             {
                 result = new ValidationResult<PpsnValue>(false, default, ValidationError.Format);
-                return true;
+                return false;
             }
         char check = buffer[7];
         if (!char.IsLetter(check))
         {
             result = new ValidationResult<PpsnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         char second = len == 9 ? buffer[8] : 'W';
         if (len == 9 && !char.IsLetter(second))
         {
             result = new ValidationResult<PpsnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         int sum = 0;
         int[] weights = { 8, 7, 6, 5, 4, 3, 2 };
@@ -55,14 +55,14 @@ public static class Ppsn
         if (secondVal < 0)
         {
             result = new ValidationResult<PpsnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         sum += secondVal * 9;
         char expected = CheckMap[sum % 23];
         if (check != expected)
         {
             result = new ValidationResult<PpsnValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<PpsnValue>(true, new PpsnValue(new string(buffer[..len])), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/IN/Gstin.cs
+++ b/src/Veritas/Tax/IN/Gstin.cs
@@ -12,7 +12,7 @@ public readonly struct GstinValue
 public static class Gstin
 {
     private const string Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-    private static readonly int[] Weights = new[] {1,2,3,4,5,6,7,8,9,10,1,2,3,4};
+    private static readonly int[] Weights = new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<GstinValue> result)
     {
@@ -20,18 +20,18 @@ public static class Gstin
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<GstinValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 15)
         {
             result = new ValidationResult<GstinValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 14; i++)
         {
             int v = Alphabet.IndexOf(chars[i]);
-            if (v < 0) { result = new ValidationResult<GstinValue>(false, default, ValidationError.Charset); return true; }
+            if (v < 0) { result = new ValidationResult<GstinValue>(false, default, ValidationError.Charset); return false; }
             sum += v * Weights[i];
         }
         int check = (36 - (sum % 36)) % 36;
@@ -39,7 +39,7 @@ public static class Gstin
         if (chars[14] != expected)
         {
             result = new ValidationResult<GstinValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<GstinValue>(true, new GstinValue(new string(chars)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/IN/Pan.cs
+++ b/src/Veritas/Tax/IN/Pan.cs
@@ -19,22 +19,22 @@ public static class Pan
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<PanValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 10)
         {
             result = new ValidationResult<PanValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         // pattern: 5 letters, 4 digits, 1 letter
-        for (int i = 0; i < 5; i++) if (!char.IsLetter(chars[i])) { result = new ValidationResult<PanValue>(false, default, ValidationError.Charset); return true; }
-        for (int i = 5; i < 9; i++) if (!char.IsDigit(chars[i])) { result = new ValidationResult<PanValue>(false, default, ValidationError.Charset); return true; }
-        if (!char.IsLetter(chars[9])) { result = new ValidationResult<PanValue>(false, default, ValidationError.Charset); return true; }
+        for (int i = 0; i < 5; i++) if (!char.IsLetter(chars[i])) { result = new ValidationResult<PanValue>(false, default, ValidationError.Charset); return false; }
+        for (int i = 5; i < 9; i++) if (!char.IsDigit(chars[i])) { result = new ValidationResult<PanValue>(false, default, ValidationError.Charset); return false; }
+        if (!char.IsLetter(chars[9])) { result = new ValidationResult<PanValue>(false, default, ValidationError.Charset); return false; }
         int sum = 0;
         for (int i = 0; i < 9; i++)
         {
             int v = Alphabet.IndexOf(chars[i]);
-            if (v < 0) { result = new ValidationResult<PanValue>(false, default, ValidationError.Charset); return true; }
+            if (v < 0) { result = new ValidationResult<PanValue>(false, default, ValidationError.Charset); return false; }
             sum += v * (i + 1);
         }
         int check = sum % 36;
@@ -42,7 +42,7 @@ public static class Pan
         if (chars[9] != expected)
         {
             result = new ValidationResult<PanValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<PanValue>(true, new PanValue(new string(chars)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/IS/Kennitala.cs
+++ b/src/Veritas/Tax/IS/Kennitala.cs
@@ -14,7 +14,7 @@ public readonly struct KennitalaValue
 /// </summary>
 public static class Kennitala
 {
-    private static readonly int[] Weights = {3,2,7,6,5,4,3,2};
+    private static readonly int[] Weights = { 3, 2, 7, 6, 5, 4, 3, 2 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<KennitalaValue> result)
     {
@@ -22,23 +22,23 @@ public static class Kennitala
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<KennitalaValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 10)
         {
             result = new ValidationResult<KennitalaValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (digits[9] != '0' && digits[9] != '9')
         {
             result = new ValidationResult<KennitalaValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits);
-        if (digits[8]-'0' != check)
+        if (digits[8] - '0' != check)
         {
             result = new ValidationResult<KennitalaValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<KennitalaValue>(true, new KennitalaValue(new string(digits)), ValidationError.None);
         return true;
@@ -49,47 +49,47 @@ public static class Kennitala
 
     public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
     {
-        written=0;
-        if (destination.Length <10) return false;
+        written = 0;
+        if (destination.Length < 10) return false;
         var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
         Span<char> digits = destination[..10];
-        int year = rng.Next(1900,2100);
-        int month = rng.Next(1,13);
-        int day = rng.Next(1, DateTime.DaysInMonth(year,month)+1);
-        digits[0]=(char)('0'+(day/10));
-        digits[1]=(char)('0'+(day%10));
-        digits[2]=(char)('0'+(month/10));
-        digits[3]=(char)('0'+(month%10));
-        digits[4]=(char)('0'+(year%100/10));
-        digits[5]=(char)('0'+(year%10));
-        digits[6]=(char)('0'+rng.Next(10));
-        digits[7]=(char)('0'+rng.Next(10));
-        digits[8]=(char)('0'+ComputeCheckDigit(digits));
-        digits[9]=(char)('0'+(year>=2000?0:9));
-        written=10;
+        int year = rng.Next(1900, 2100);
+        int month = rng.Next(1, 13);
+        int day = rng.Next(1, DateTime.DaysInMonth(year, month) + 1);
+        digits[0] = (char)('0' + (day / 10));
+        digits[1] = (char)('0' + (day % 10));
+        digits[2] = (char)('0' + (month / 10));
+        digits[3] = (char)('0' + (month % 10));
+        digits[4] = (char)('0' + (year % 100 / 10));
+        digits[5] = (char)('0' + (year % 10));
+        digits[6] = (char)('0' + rng.Next(10));
+        digits[7] = (char)('0' + rng.Next(10));
+        digits[8] = (char)('0' + ComputeCheckDigit(digits));
+        digits[9] = (char)('0' + (year >= 2000 ? 0 : 9));
+        written = 10;
         return true;
     }
 
     private static int ComputeCheckDigit(ReadOnlySpan<char> digits)
     {
-        int sum=0;
-        for(int i=0;i<Weights.Length;i++)
-            sum += (digits[i]-'0')*Weights[i];
-        int r = 11 - (sum%11);
-        if (r==11) return 0;
-        if (r==10) return -1; // invalid
+        int sum = 0;
+        for (int i = 0; i < Weights.Length; i++)
+            sum += (digits[i] - '0') * Weights[i];
+        int r = 11 - (sum % 11);
+        if (r == 11) return 0;
+        if (r == 10) return -1; // invalid
         return r;
     }
 
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
     {
-        len=0;
-        foreach(var ch in input)
+        len = 0;
+        foreach (var ch in input)
         {
-            if (ch=='-'||ch==' ') continue;
-            if(!char.IsDigit(ch)) { len=0; return false; }
-            if (len>=dest.Length){ len=0; return false; }
-            dest[len++]=ch;
+            if (ch == '-' || ch == ' ') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
         }
         return true;
     }

--- a/src/Veritas/Tax/IT/CodiceFiscale.cs
+++ b/src/Veritas/Tax/IT/CodiceFiscale.cs
@@ -29,26 +29,26 @@ public static class CodiceFiscale
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<CodiceFiscaleValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 16)
         {
             result = new ValidationResult<CodiceFiscaleValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 15; i++)
         {
             char c = chars[i];
             int idx = EvenMap.IndexOf(c);
-            if (idx < 0) { result = new ValidationResult<CodiceFiscaleValue>(false, default, ValidationError.Charset); return true; }
+            if (idx < 0) { result = new ValidationResult<CodiceFiscaleValue>(false, default, ValidationError.Charset); return false; }
             if ((i & 1) == 0) sum += OddMap[idx]; else sum += idx;
         }
         char check = (char)('A' + (sum % 26));
         if (chars[15] != check)
         {
             result = new ValidationResult<CodiceFiscaleValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<CodiceFiscaleValue>(true, new CodiceFiscaleValue(new string(chars)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/IT/Piva.cs
+++ b/src/Veritas/Tax/IT/Piva.cs
@@ -17,12 +17,12 @@ public static class Piva
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<PivaValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<PivaValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 10; i++)
@@ -43,7 +43,7 @@ public static class Piva
         if (check != digits[10] - '0')
         {
             result = new ValidationResult<PivaValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<PivaValue>(true, new PivaValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/LT/AsmensKodas.cs
+++ b/src/Veritas/Tax/LT/AsmensKodas.cs
@@ -14,8 +14,8 @@ public readonly struct AsmensKodasValue
 /// </summary>
 public static class AsmensKodas
 {
-    private static readonly int[] Weights1 = {1,2,3,4,5,6,7,8,9,1};
-    private static readonly int[] Weights2 = {3,4,5,6,7,8,9,1,2,3};
+    private static readonly int[] Weights1 = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 1 };
+    private static readonly int[] Weights2 = { 3, 4, 5, 6, 7, 8, 9, 1, 2, 3 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<AsmensKodasValue> result)
     {
@@ -23,18 +23,18 @@ public static class AsmensKodas
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<AsmensKodasValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<AsmensKodasValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..10]);
-        if (digits[10]-'0' != check)
+        if (digits[10] - '0' != check)
         {
             result = new ValidationResult<AsmensKodasValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<AsmensKodasValue>(true, new AsmensKodasValue(new string(digits)), ValidationError.None);
         return true;
@@ -45,48 +45,48 @@ public static class AsmensKodas
 
     public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
     {
-        written=0;
-        if (destination.Length<11) return false;
+        written = 0;
+        if (destination.Length < 11) return false;
         var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
         Span<char> digits = destination[..11];
-        int year=rng.Next(1900,2100);
-        int month=rng.Next(1,13);
-        int day=rng.Next(1, DateTime.DaysInMonth(year,month)+1);
-        int s = year>=2000? (rng.Next(2)==0?5:6) : (year>=1900? (rng.Next(2)==0?3:4):1);
-        digits[0]=(char)('0'+s);
-        digits[1]=(char)('0'+(year%100/10));
-        digits[2]=(char)('0'+(year%10));
-        digits[3]=(char)('0'+(month/10));
-        digits[4]=(char)('0'+(month%10));
-        digits[5]=(char)('0'+(day/10));
-        digits[6]=(char)('0'+(day%10));
-        for(int i=7;i<10;i++) digits[i]=(char)('0'+rng.Next(10));
-        digits[10]=(char)('0'+ComputeCheckDigit(digits[..10]));
-        written=11;
+        int year = rng.Next(1900, 2100);
+        int month = rng.Next(1, 13);
+        int day = rng.Next(1, DateTime.DaysInMonth(year, month) + 1);
+        int s = year >= 2000 ? (rng.Next(2) == 0 ? 5 : 6) : (year >= 1900 ? (rng.Next(2) == 0 ? 3 : 4) : 1);
+        digits[0] = (char)('0' + s);
+        digits[1] = (char)('0' + (year % 100 / 10));
+        digits[2] = (char)('0' + (year % 10));
+        digits[3] = (char)('0' + (month / 10));
+        digits[4] = (char)('0' + (month % 10));
+        digits[5] = (char)('0' + (day / 10));
+        digits[6] = (char)('0' + (day % 10));
+        for (int i = 7; i < 10; i++) digits[i] = (char)('0' + rng.Next(10));
+        digits[10] = (char)('0' + ComputeCheckDigit(digits[..10]));
+        written = 11;
         return true;
     }
 
     private static int ComputeCheckDigit(ReadOnlySpan<char> digits)
     {
-        int sum=0;
-        for(int i=0;i<Weights1.Length;i++) sum += (digits[i]-'0')*Weights1[i];
-        int r=sum%11;
-        if (r<10) return r;
-        sum=0;
-        for(int i=0;i<Weights2.Length;i++) sum += (digits[i]-'0')*Weights2[i];
-        r=sum%11;
-        return r<10? r : 0;
+        int sum = 0;
+        for (int i = 0; i < Weights1.Length; i++) sum += (digits[i] - '0') * Weights1[i];
+        int r = sum % 11;
+        if (r < 10) return r;
+        sum = 0;
+        for (int i = 0; i < Weights2.Length; i++) sum += (digits[i] - '0') * Weights2[i];
+        r = sum % 11;
+        return r < 10 ? r : 0;
     }
 
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
     {
-        len=0;
-        foreach(var ch in input)
+        len = 0;
+        foreach (var ch in input)
         {
-            if (ch=='-'||ch==' ') continue;
-            if(!char.IsDigit(ch)){ len=0; return false; }
-            if(len>=dest.Length){ len=0; return false; }
-            dest[len++]=ch;
+            if (ch == '-' || ch == ' ') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
         }
         return true;
     }

--- a/src/Veritas/Tax/LV/PersonasKods.cs
+++ b/src/Veritas/Tax/LV/PersonasKods.cs
@@ -14,7 +14,7 @@ public readonly struct PersonasKodsValue
 /// </summary>
 public static class PersonasKods
 {
-    private static readonly int[] Weights = {1,6,3,7,9,10,5,8,4,2};
+    private static readonly int[] Weights = { 1, 6, 3, 7, 9, 10, 5, 8, 4, 2 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<PersonasKodsValue> result)
     {
@@ -22,18 +22,18 @@ public static class PersonasKods
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<PersonasKodsValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<PersonasKodsValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..10]);
-        if (digits[10]-'0' != check)
+        if (digits[10] - '0' != check)
         {
             result = new ValidationResult<PersonasKodsValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<PersonasKodsValue>(true, new PersonasKodsValue(new string(digits)), ValidationError.None);
         return true;
@@ -44,45 +44,45 @@ public static class PersonasKods
 
     public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
     {
-        written=0;
-        if (destination.Length<11) return false;
+        written = 0;
+        if (destination.Length < 11) return false;
         var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
         Span<char> digits = destination[..11];
-        int year=rng.Next(1900,2100);
-        int month=rng.Next(1,13);
-        int day=rng.Next(1, DateTime.DaysInMonth(year,month)+1);
-        digits[0]=(char)('0'+(day/10));
-        digits[1]=(char)('0'+(day%10));
-        digits[2]=(char)('0'+(month/10));
-        digits[3]=(char)('0'+(month%10));
-        digits[4]=(char)('0'+(year%100/10));
-        digits[5]=(char)('0'+(year%10));
-        digits[6]=(char)('0'+rng.Next(10));
-        digits[7]=(char)('0'+rng.Next(10));
-        digits[8]=(char)('0'+rng.Next(10));
-        digits[9]=(char)('0'+rng.Next(10));
-        digits[10]=(char)('0'+ComputeCheckDigit(digits[..10]));
-        written=11;
+        int year = rng.Next(1900, 2100);
+        int month = rng.Next(1, 13);
+        int day = rng.Next(1, DateTime.DaysInMonth(year, month) + 1);
+        digits[0] = (char)('0' + (day / 10));
+        digits[1] = (char)('0' + (day % 10));
+        digits[2] = (char)('0' + (month / 10));
+        digits[3] = (char)('0' + (month % 10));
+        digits[4] = (char)('0' + (year % 100 / 10));
+        digits[5] = (char)('0' + (year % 10));
+        digits[6] = (char)('0' + rng.Next(10));
+        digits[7] = (char)('0' + rng.Next(10));
+        digits[8] = (char)('0' + rng.Next(10));
+        digits[9] = (char)('0' + rng.Next(10));
+        digits[10] = (char)('0' + ComputeCheckDigit(digits[..10]));
+        written = 11;
         return true;
     }
 
     private static int ComputeCheckDigit(ReadOnlySpan<char> digits)
     {
-        int sum=0;
-        for(int i=0;i<Weights.Length;i++) sum += (digits[i]-'0')*Weights[i];
+        int sum = 0;
+        for (int i = 0; i < Weights.Length; i++) sum += (digits[i] - '0') * Weights[i];
         int r = (sum + 1) % 11;
         return r == 10 ? 0 : r;
     }
 
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
     {
-        len=0;
-        foreach(var ch in input)
+        len = 0;
+        foreach (var ch in input)
         {
-            if (ch=='-'||ch==' ') continue;
-            if(!char.IsDigit(ch)){ len=0; return false; }
-            if(len>=dest.Length){ len=0; return false; }
-            dest[len++]=ch;
+            if (ch == '-' || ch == ' ') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
         }
         return true;
     }

--- a/src/Veritas/Tax/MX/Rfc.cs
+++ b/src/Veritas/Tax/MX/Rfc.cs
@@ -22,19 +22,19 @@ public static class Rfc
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<RfcValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 12 && len != 13)
         {
             result = new ValidationResult<RfcValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int totalLen = len;
         int sum = 0;
         for (int i = 0; i < totalLen - 1; i++)
         {
             int v = Alphabet.IndexOf(chars[i]);
-            if (v < 0) { result = new ValidationResult<RfcValue>(false, default, ValidationError.Charset); return true; }
+            if (v < 0) { result = new ValidationResult<RfcValue>(false, default, ValidationError.Charset); return false; }
             sum += v * (totalLen - i);
         }
         int checkVal = 11 - (sum % 11);
@@ -42,7 +42,7 @@ public static class Rfc
         if (chars[totalLen - 1] != expected)
         {
             result = new ValidationResult<RfcValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<RfcValue>(true, new RfcValue(new string(chars[..totalLen])), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/NL/Bsn.cs
+++ b/src/Veritas/Tax/NL/Bsn.cs
@@ -17,12 +17,12 @@ public static class Bsn
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<BsnValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<BsnValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 8; i++)
@@ -33,7 +33,7 @@ public static class Bsn
         if (sum % 11 != 0)
         {
             result = new ValidationResult<BsnValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<BsnValue>(true, new BsnValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/NL/Btw.cs
+++ b/src/Veritas/Tax/NL/Btw.cs
@@ -17,19 +17,19 @@ public static class Btw
         if (!Normalize(input, buffer, out int len))
         {
             result = new ValidationResult<BtwValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 12 || buffer[9] != 'B')
         {
             result = new ValidationResult<BtwValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         for (int i = 0; i < 9; i++)
         {
             if (buffer[i] < '0' || buffer[i] > '9')
             {
                 result = new ValidationResult<BtwValue>(false, default, ValidationError.Format);
-                return true;
+                return false;
             }
         }
         int sum = 0;
@@ -42,13 +42,13 @@ public static class Btw
         if (check != buffer[8] - '0')
         {
             result = new ValidationResult<BtwValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         // last two digits after B are extension; any digits ok
         if (buffer[10] < '0' || buffer[10] > '9' || buffer[11] < '0' || buffer[11] > '9')
         {
             result = new ValidationResult<BtwValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         result = new ValidationResult<BtwValue>(true, new BtwValue(new string(buffer)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/NO/Fodselsnummer.cs
+++ b/src/Veritas/Tax/NO/Fodselsnummer.cs
@@ -14,8 +14,8 @@ public readonly struct FodselsnummerValue
 /// </summary>
 public static class Fodselsnummer
 {
-    private static readonly int[] Weights1 = {3,7,6,1,8,9,4,5,2};
-    private static readonly int[] Weights2 = {5,4,3,2,7,6,5,4,3,2};
+    private static readonly int[] Weights1 = { 3, 7, 6, 1, 8, 9, 4, 5, 2 };
+    private static readonly int[] Weights2 = { 5, 4, 3, 2, 7, 6, 5, 4, 3, 2 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<FodselsnummerValue> result)
     {
@@ -23,24 +23,24 @@ public static class Fodselsnummer
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<FodselsnummerValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<FodselsnummerValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int k1 = ComputeK1(digits);
         if (k1 < 0 || k1 != digits[9] - '0')
         {
             result = new ValidationResult<FodselsnummerValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         int k2 = ComputeK2(digits, k1);
         if (k2 < 0 || k2 != digits[10] - '0')
         {
             result = new ValidationResult<FodselsnummerValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<FodselsnummerValue>(true, new FodselsnummerValue(new string(digits)), ValidationError.None);
         return true;
@@ -60,7 +60,7 @@ public static class Fodselsnummer
             int year = rng.Next(1900, 2100);
             int month = rng.Next(1, 13);
             int day = rng.Next(1, DateTime.DaysInMonth(year, month) + 1);
-            if (rng.Next(0,2) == 1) day += 40; // D-number
+            if (rng.Next(0, 2) == 1) day += 40; // D-number
             int individual = rng.Next(0, 1000);
             int yy = year % 100;
             digits[0] = (char)('0' + (day / 10));
@@ -86,8 +86,8 @@ public static class Fodselsnummer
     private static int ComputeK1(ReadOnlySpan<char> digits)
     {
         int sum = 0;
-        for (int i=0;i<9;i++) sum += (digits[i]-'0')*Weights1[i];
-        int r = 11 - sum%11;
+        for (int i = 0; i < 9; i++) sum += (digits[i] - '0') * Weights1[i];
+        int r = 11 - sum % 11;
         if (r == 11) return 0;
         if (r == 10) return -1;
         return r;
@@ -96,9 +96,9 @@ public static class Fodselsnummer
     private static int ComputeK2(ReadOnlySpan<char> digits, int k1)
     {
         int sum = 0;
-        for (int i=0;i<9;i++) sum += (digits[i]-'0')*Weights2[i];
-        sum += k1*2;
-        int r = 11 - sum%11;
+        for (int i = 0; i < 9; i++) sum += (digits[i] - '0') * Weights2[i];
+        sum += k1 * 2;
+        int r = 11 - sum % 11;
         if (r == 11) return 0;
         if (r == 10) return -1;
         return r;
@@ -109,12 +109,12 @@ public static class Fodselsnummer
         len = 0;
         foreach (var ch in input)
         {
-            if (ch==' '||ch=='-') continue;
-            if (!char.IsDigit(ch) || len>=dest.Length)
+            if (ch == ' ' || ch == '-') continue;
+            if (!char.IsDigit(ch) || len >= dest.Length)
             {
                 len = 0; return false;
             }
-            dest[len++]=ch;
+            dest[len++] = ch;
         }
         return true;
     }

--- a/src/Veritas/Tax/NO/Kid.cs
+++ b/src/Veritas/Tax/NO/Kid.cs
@@ -26,18 +26,18 @@ public static class Kid
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<KidValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len < 2 || len > 25)
         {
             result = new ValidationResult<KidValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         bool ok = variant == KidVariant.Mod10 ? VerifyMod10(digits[..len]) : VerifyMod11(digits[..len]);
         if (!ok)
         {
             result = new ValidationResult<KidValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<KidValue>(true, new KidValue(new string(digits[..len])), ValidationError.None);
         return true;
@@ -54,9 +54,9 @@ public static class Kid
         for (int i = 0; i < length - 1; i++)
             destination[i] = (char)('0' + rng.Next(0, 10));
         if (variant == KidVariant.Mod10)
-            destination[length - 1] = (char)('0' + ComputeMod10(destination[..(length-1)]));
+            destination[length - 1] = (char)('0' + ComputeMod10(destination[..(length - 1)]));
         else
-            destination[length - 1] = (char)('0' + ComputeMod11(destination[..(length-1)]));
+            destination[length - 1] = (char)('0' + ComputeMod11(destination[..(length - 1)]));
         written = length;
         return true;
     }
@@ -133,7 +133,7 @@ public static class Kid
         len = 0;
         foreach (var ch in input)
         {
-            if (ch==' '||ch=='-') continue;
+            if (ch == ' ' || ch == '-') continue;
             if (!char.IsDigit(ch) || len >= dest.Length)
             {
                 len = 0; return false;

--- a/src/Veritas/Tax/NZ/Ird.cs
+++ b/src/Veritas/Tax/NZ/Ird.cs
@@ -11,8 +11,8 @@ public readonly struct IrdValue
 
 public static class Ird
 {
-    private static readonly int[] PrimaryWeights = {3,2,7,6,5,4,3,2};
-    private static readonly int[] SecondaryWeights = {7,4,3,2,5,2,7,6};
+    private static readonly int[] PrimaryWeights = { 3, 2, 7, 6, 5, 4, 3, 2 };
+    private static readonly int[] SecondaryWeights = { 7, 4, 3, 2, 5, 2, 7, 6 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<IrdValue> result)
     {
@@ -20,12 +20,12 @@ public static class Ird
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<IrdValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len < 8 || len > 9)
         {
             result = new ValidationResult<IrdValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         Span<char> padded = stackalloc char[9];
         int offset = 9 - len;
@@ -37,7 +37,7 @@ public static class Ird
         if (check == 10 || padded[8] - '0' != check)
         {
             result = new ValidationResult<IrdValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<IrdValue>(true, new IrdValue(new string(padded)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/PE/Ruc.cs
+++ b/src/Veritas/Tax/PE/Ruc.cs
@@ -14,7 +14,7 @@ public readonly struct RucValue
 /// </summary>
 public static class Ruc
 {
-    private static readonly int[] Weights = {5,4,3,2,7,6,5,4,3,2};
+    private static readonly int[] Weights = { 5, 4, 3, 2, 7, 6, 5, 4, 3, 2 };
 
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<RucValue> result)
     {
@@ -22,18 +22,18 @@ public static class Ruc
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<RucValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<RucValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..10]);
-        if (digits[10]-'0' != check)
+        if (digits[10] - '0' != check)
         {
             result = new ValidationResult<RucValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<RucValue>(true, new RucValue(new string(digits)), ValidationError.None);
         return true;
@@ -44,35 +44,35 @@ public static class Ruc
 
     public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
     {
-        written=0;
-        if(destination.Length<11) return false;
+        written = 0;
+        if (destination.Length < 11) return false;
         var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
         Span<char> digits = destination[..11];
-        for(int i=0;i<10;i++) digits[i]=(char)('0'+rng.Next(10));
-        digits[10]=(char)('0'+ComputeCheckDigit(digits[..10]));
-        written=11;
+        for (int i = 0; i < 10; i++) digits[i] = (char)('0' + rng.Next(10));
+        digits[10] = (char)('0' + ComputeCheckDigit(digits[..10]));
+        written = 11;
         return true;
     }
 
     private static int ComputeCheckDigit(ReadOnlySpan<char> digits)
     {
-        int sum=0;
-        for(int i=0;i<Weights.Length;i++) sum += (digits[i]-'0')*Weights[i];
+        int sum = 0;
+        for (int i = 0; i < Weights.Length; i++) sum += (digits[i] - '0') * Weights[i];
         int r = 11 - (sum % 11);
-        if (r==10) return 0;
-        if (r==11) return 1;
+        if (r == 10) return 0;
+        if (r == 11) return 1;
         return r;
     }
 
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
     {
-        len=0;
-        foreach(var ch in input)
+        len = 0;
+        foreach (var ch in input)
         {
-            if (ch==' '||ch=='-') continue;
-            if(!char.IsDigit(ch)){ len=0; return false; }
-            if(len>=dest.Length){ len=0; return false; }
-            dest[len++]=ch;
+            if (ch == ' ' || ch == '-') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
         }
         return true;
     }

--- a/src/Veritas/Tax/PL/Nip.cs
+++ b/src/Veritas/Tax/PL/Nip.cs
@@ -19,12 +19,12 @@ public static class Nip
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<NipValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 10)
         {
             result = new ValidationResult<NipValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 9; i++)
@@ -33,7 +33,7 @@ public static class Nip
         if (check == 10 || check != digits[9] - '0')
         {
             result = new ValidationResult<NipValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<NipValue>(true, new NipValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/PL/Pesel.cs
+++ b/src/Veritas/Tax/PL/Pesel.cs
@@ -19,17 +19,17 @@ public static class Pesel
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<PeselValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 11)
         {
             result = new ValidationResult<PeselValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!IsValidDate(digits))
         {
             result = new ValidationResult<PeselValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 10; i++)
@@ -38,7 +38,7 @@ public static class Pesel
         if (check != digits[10] - '0')
         {
             result = new ValidationResult<PeselValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<PeselValue>(true, new PeselValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/PL/Regon.cs
+++ b/src/Veritas/Tax/PL/Regon.cs
@@ -20,12 +20,12 @@ public static class Regon
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<RegonValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9 && len != 14)
         {
             result = new ValidationResult<RegonValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (len == 9)
         {
@@ -37,7 +37,7 @@ public static class Regon
             if (check != digits[8] - '0')
             {
                 result = new ValidationResult<RegonValue>(false, default, ValidationError.Checksum);
-                return true;
+                return false;
             }
         }
         else
@@ -50,7 +50,7 @@ public static class Regon
             if (check != digits[13] - '0')
             {
                 result = new ValidationResult<RegonValue>(false, default, ValidationError.Checksum);
-                return true;
+                return false;
             }
         }
         result = new ValidationResult<RegonValue>(true, new RegonValue(new string(digits[..len])), ValidationError.None);

--- a/src/Veritas/Tax/PT/Nif.cs
+++ b/src/Veritas/Tax/PT/Nif.cs
@@ -22,12 +22,12 @@ public static class Nif
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<NifValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<NifValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int first = digits[0] - '0';
         bool okFirst = false;
@@ -36,7 +36,7 @@ public static class Nif
         if (!okFirst)
         {
             result = new ValidationResult<NifValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 8; i++)
@@ -46,7 +46,7 @@ public static class Nif
         if (digits[8] - '0' != check)
         {
             result = new ValidationResult<NifValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<NifValue>(true, new NifValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/RO/Cnp.cs
+++ b/src/Veritas/Tax/RO/Cnp.cs
@@ -22,18 +22,18 @@ public static class Cnp
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<CnpValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 13)
         {
             result = new ValidationResult<CnpValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..12]);
         if (digits[12] - '0' != check)
         {
             result = new ValidationResult<CnpValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<CnpValue>(true, new CnpValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/RS/Jmbg.cs
+++ b/src/Veritas/Tax/RS/Jmbg.cs
@@ -22,18 +22,18 @@ public static class Jmbg
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<JmbgValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 13)
         {
             result = new ValidationResult<JmbgValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..12]);
         if (digits[12] - '0' != check)
         {
             result = new ValidationResult<JmbgValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<JmbgValue>(true, new JmbgValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/SE/OrgNr.cs
+++ b/src/Veritas/Tax/SE/OrgNr.cs
@@ -18,23 +18,23 @@ public static class OrgNr
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<OrgNrValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 10 && len != 12)
         {
             result = new ValidationResult<OrgNrValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         ReadOnlySpan<char> num = len == 10 ? digits[..10] : digits[(len - 10)..len];
         if (num[2] < '2')
         {
             result = new ValidationResult<OrgNrValue>(false, default, ValidationError.CountryRule);
-            return true;
+            return false;
         }
         if (!Luhn.Validate(num))
         {
             result = new ValidationResult<OrgNrValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<OrgNrValue>(true, new OrgNrValue(new string(digits[..len])), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/SE/Personnummer.cs
+++ b/src/Veritas/Tax/SE/Personnummer.cs
@@ -18,23 +18,23 @@ public static class Personnummer
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<PersonnummerValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 10 && len != 12)
         {
             result = new ValidationResult<PersonnummerValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         ReadOnlySpan<char> num = len == 10 ? digits[..10] : digits[(len - 10)..len];
         if (!IsValidDate(num))
         {
             result = new ValidationResult<PersonnummerValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (!Luhn.Validate(num))
         {
             result = new ValidationResult<PersonnummerValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<PersonnummerValue>(true, new PersonnummerValue(new string(digits[..len])), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/SG/Uen.cs
+++ b/src/Veritas/Tax/SG/Uen.cs
@@ -22,18 +22,18 @@ public static class Uen
         if (!Normalize(input, chars, out int len))
         {
             result = new ValidationResult<UenValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9 && len != 10)
         {
             result = new ValidationResult<UenValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < len - 1; i++)
         {
             int v = Alphabet.IndexOf(chars[i]);
-            if (v < 0) { result = new ValidationResult<UenValue>(false, default, ValidationError.Charset); return true; }
+            if (v < 0) { result = new ValidationResult<UenValue>(false, default, ValidationError.Charset); return false; }
             sum += v * (len - i);
         }
         int checkVal = (11 - (sum % 11)) % 11;
@@ -41,7 +41,7 @@ public static class Uen
         if (chars[len - 1] != expected)
         {
             result = new ValidationResult<UenValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<UenValue>(true, new UenValue(new string(chars[..len])), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/SI/Emso.cs
+++ b/src/Veritas/Tax/SI/Emso.cs
@@ -22,18 +22,18 @@ public static class Emso
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<EmsoValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 13)
         {
             result = new ValidationResult<EmsoValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int check = ComputeCheckDigit(digits[..12]);
         if (digits[12] - '0' != check)
         {
             result = new ValidationResult<EmsoValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<EmsoValue>(true, new EmsoValue(new string(digits)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/SK/RodneCislo.cs
+++ b/src/Veritas/Tax/SK/RodneCislo.cs
@@ -20,19 +20,19 @@ public static class RodneCislo
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<RodneCisloValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9 && len != 10)
         {
             result = new ValidationResult<RodneCisloValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (len == 9)
         {
             if (ParseLong(digits[..9]) % 11 != 0)
             {
                 result = new ValidationResult<RodneCisloValue>(false, default, ValidationError.Checksum);
-                return true;
+                return false;
             }
         }
         else
@@ -43,7 +43,7 @@ public static class RodneCislo
             if (check != digits[9] - '0')
             {
                 result = new ValidationResult<RodneCisloValue>(false, default, ValidationError.Checksum);
-                return true;
+                return false;
             }
         }
         result = new ValidationResult<RodneCisloValue>(true, new RodneCisloValue(new string(digits[..len])), ValidationError.None);
@@ -84,7 +84,7 @@ public static class RodneCislo
     private static long ParseLong(ReadOnlySpan<char> digits)
     {
         long n = 0;
-        foreach (var ch in digits) n = n*10 + (ch - '0');
+        foreach (var ch in digits) n = n * 10 + (ch - '0');
         return n;
     }
 

--- a/src/Veritas/Tax/TR/Tckn.cs
+++ b/src/Veritas/Tax/TR/Tckn.cs
@@ -20,31 +20,31 @@ public static class Tckn
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<TcknValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
-        if (len != 11 || digits[0]=='0')
+        if (len != 11 || digits[0] == '0')
         {
             result = new ValidationResult<TcknValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
-        int oddSum = 0, evenSum=0;
-        for(int i=0;i<9;i++)
+        int oddSum = 0, evenSum = 0;
+        for (int i = 0; i < 9; i++)
         {
-            int d = digits[i]-'0';
-            if ((i%2)==0) oddSum += d; else evenSum += d;
+            int d = digits[i] - '0';
+            if ((i % 2) == 0) oddSum += d; else evenSum += d;
         }
-        int d10 = ((oddSum*7) - evenSum) % 10;
-        if (d10 <0) d10 +=10;
-        if (digits[9]-'0' != d10)
+        int d10 = ((oddSum * 7) - evenSum) % 10;
+        if (d10 < 0) d10 += 10;
+        if (digits[9] - '0' != d10)
         {
             result = new ValidationResult<TcknValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         int sumAll = oddSum + evenSum + d10;
-        if (digits[10]-'0' != sumAll % 10)
+        if (digits[10] - '0' != sumAll % 10)
         {
             result = new ValidationResult<TcknValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<TcknValue>(true, new TcknValue(new string(digits)), ValidationError.None);
         return true;
@@ -55,35 +55,35 @@ public static class Tckn
 
     public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
     {
-        written=0;
-        if (destination.Length<11) return false;
+        written = 0;
+        if (destination.Length < 11) return false;
         var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
         Span<char> digits = destination[..11];
-        digits[0]=(char)('1'+rng.Next(9));
-        for(int i=1;i<9;i++) digits[i]=(char)('0'+rng.Next(10));
-        int oddSum=0, evenSum=0;
-        for(int i=0;i<9;i++)
+        digits[0] = (char)('1' + rng.Next(9));
+        for (int i = 1; i < 9; i++) digits[i] = (char)('0' + rng.Next(10));
+        int oddSum = 0, evenSum = 0;
+        for (int i = 0; i < 9; i++)
         {
-            int d=digits[i]-'0';
-            if ((i%2)==0) oddSum+=d; else evenSum+=d;
+            int d = digits[i] - '0';
+            if ((i % 2) == 0) oddSum += d; else evenSum += d;
         }
-        int d10=((oddSum*7)-evenSum)%10; if(d10<0)d10+=10;
-        digits[9]=(char)('0'+d10);
-        int sumAll=oddSum+evenSum+d10;
-        digits[10]=(char)('0'+(sumAll%10));
-        written=11;
+        int d10 = ((oddSum * 7) - evenSum) % 10; if (d10 < 0) d10 += 10;
+        digits[9] = (char)('0' + d10);
+        int sumAll = oddSum + evenSum + d10;
+        digits[10] = (char)('0' + (sumAll % 10));
+        written = 11;
         return true;
     }
 
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
     {
-        len=0;
-        foreach(var ch in input)
+        len = 0;
+        foreach (var ch in input)
         {
-            if (ch==' '||ch=='-') continue;
-            if(!char.IsDigit(ch)){ len=0; return false; }
-            if(len>=dest.Length){ len=0; return false; }
-            dest[len++]=ch;
+            if (ch == ' ' || ch == '-') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
         }
         return true;
     }

--- a/src/Veritas/Tax/UK/CompanyNumber.cs
+++ b/src/Veritas/Tax/UK/CompanyNumber.cs
@@ -27,19 +27,19 @@ public static class CompanyNumber
             }
             else if (u >= '0' && u <= '9')
             {
-                if (len >= 8) { result = new ValidationResult<CompanyNumberValue>(false, default, ValidationError.Length); return true; }
+                if (len >= 8) { result = new ValidationResult<CompanyNumberValue>(false, default, ValidationError.Length); return false; }
                 buf[len++] = u;
             }
             else
             {
                 result = new ValidationResult<CompanyNumberValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
         }
         if (len != 8 || (letterCount != 0 && letterCount != 2))
         {
             result = new ValidationResult<CompanyNumberValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         result = new ValidationResult<CompanyNumberValue>(true, new CompanyNumberValue(new string(buf)), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/UK/Nino.cs
+++ b/src/Veritas/Tax/UK/Nino.cs
@@ -17,21 +17,21 @@ public static class Nino
             char u = char.ToUpperInvariant(ch);
             if (len < 2)
             {
-                if (u < 'A' || u > 'Z') { result = new ValidationResult<NinoValue>(false, default, ValidationError.Charset); return true; }
+                if (u < 'A' || u > 'Z') { result = new ValidationResult<NinoValue>(false, default, ValidationError.Charset); return false; }
             }
             else if (len < 8)
             {
-                if (u < '0' || u > '9') { result = new ValidationResult<NinoValue>(false, default, ValidationError.Charset); return true; }
+                if (u < '0' || u > '9') { result = new ValidationResult<NinoValue>(false, default, ValidationError.Charset); return false; }
             }
             else
             {
-                if (!(u == 'A' || u == 'B' || u == 'C' || u == 'D' || u == ' ')) { result = new ValidationResult<NinoValue>(false, default, ValidationError.Charset); return true; }
+                if (!(u == 'A' || u == 'B' || u == 'C' || u == 'D' || u == ' ')) { result = new ValidationResult<NinoValue>(false, default, ValidationError.Charset); return false; }
             }
-            if (len >= 9) { result = new ValidationResult<NinoValue>(false, default, ValidationError.Length); return true; }
+            if (len >= 9) { result = new ValidationResult<NinoValue>(false, default, ValidationError.Length); return false; }
             buf[len++] = u;
         }
-        if (len < 8 || len > 9) { result = new ValidationResult<NinoValue>(false, default, ValidationError.Length); return true; }
-        if ("DFIQUV".IndexOf(buf[0]) >= 0 || "DFIQUVO".IndexOf(buf[1]) >= 0) { result = new ValidationResult<NinoValue>(false, default, ValidationError.CountryRule); return true; }
+        if (len < 8 || len > 9) { result = new ValidationResult<NinoValue>(false, default, ValidationError.Length); return false; }
+        if ("DFIQUV".IndexOf(buf[0]) >= 0 || "DFIQUVO".IndexOf(buf[1]) >= 0) { result = new ValidationResult<NinoValue>(false, default, ValidationError.CountryRule); return false; }
         result = new ValidationResult<NinoValue>(true, new NinoValue(new string(buf[..len])), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Tax/UK/Utr.cs
+++ b/src/Veritas/Tax/UK/Utr.cs
@@ -20,12 +20,12 @@ public static class Utr
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<UtrValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 10)
         {
             result = new ValidationResult<UtrValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         int sum = 0;
         for (int i = 0; i < 9; i++)
@@ -34,7 +34,7 @@ public static class Utr
         if (digits[0] != check)
         {
             result = new ValidationResult<UtrValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<UtrValue>(true, new UtrValue(value), ValidationError.None);

--- a/src/Veritas/Tax/UK/Vat.cs
+++ b/src/Veritas/Tax/UK/Vat.cs
@@ -17,17 +17,17 @@ public static class Vat
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<VatValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9 && len != 12)
         {
             result = new ValidationResult<VatValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (!ValidateCore(digits[..9]))
         {
             result = new ValidationResult<VatValue>(false, default, ValidationError.Checksum);
-            return true;
+            return false;
         }
         result = new ValidationResult<VatValue>(true, new VatValue(new string(digits[..len])), ValidationError.None);
         return true;

--- a/src/Veritas/Tax/US/Ein.cs
+++ b/src/Veritas/Tax/US/Ein.cs
@@ -22,18 +22,18 @@ public static class Ein
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<EinValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<EinValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
-        int prefix = (digits[0]-'0')*10 + (digits[1]-'0');
+        int prefix = (digits[0] - '0') * 10 + (digits[1] - '0');
         if (Array.BinarySearch(Prefixes, prefix) < 0)
         {
             result = new ValidationResult<EinValue>(false, default, ValidationError.CountryRule);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<EinValue>(true, new EinValue(value), ValidationError.None);

--- a/src/Veritas/Tax/US/Itin.cs
+++ b/src/Veritas/Tax/US/Itin.cs
@@ -27,23 +27,23 @@ public static class Itin
         if (!Normalize(input, digits, out int len))
         {
             result = new ValidationResult<ItinValue>(false, default, ValidationError.Format);
-            return true;
+            return false;
         }
         if (len != 9)
         {
             result = new ValidationResult<ItinValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         if (digits[0] != '9')
         {
             result = new ValidationResult<ItinValue>(false, default, ValidationError.CountryRule);
-            return true;
+            return false;
         }
-        int group = (digits[3]-'0')*10 + (digits[4]-'0');
+        int group = (digits[3] - '0') * 10 + (digits[4] - '0');
         if (!AllowedGroups[group])
         {
             result = new ValidationResult<ItinValue>(false, default, ValidationError.CountryRule);
-            return true;
+            return false;
         }
         string value = new string(digits);
         result = new ValidationResult<ItinValue>(true, new ItinValue(value), ValidationError.None);

--- a/src/Veritas/Tax/US/Ssn.cs
+++ b/src/Veritas/Tax/US/Ssn.cs
@@ -14,16 +14,16 @@ public static class Ssn
         foreach (var ch in input)
         {
             if (ch == '-' || ch == ' ') continue;
-            if (ch < '0' || ch > '9') { result = new ValidationResult<SsnValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= 9) { result = new ValidationResult<SsnValue>(false, default, ValidationError.Length); return true; }
+            if (ch < '0' || ch > '9') { result = new ValidationResult<SsnValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 9) { result = new ValidationResult<SsnValue>(false, default, ValidationError.Length); return false; }
             digits[len++] = ch;
         }
-        if (len != 9) { result = new ValidationResult<SsnValue>(false, default, ValidationError.Length); return true; }
-        if (digits[0] == '0' && digits[1] == '0' && digits[2] == '0') { result = new ValidationResult<SsnValue>(false, default, ValidationError.CountryRule); return true; }
-        int area = (digits[0]-'0')*100 + (digits[1]-'0')*10 + (digits[2]-'0');
-        if (area == 0 || area == 666 || area >= 900) { result = new ValidationResult<SsnValue>(false, default, ValidationError.CountryRule); return true; }
-        if (digits[3] == '0' && digits[4] == '0') { result = new ValidationResult<SsnValue>(false, default, ValidationError.CountryRule); return true; }
-        if (digits[5] == '0' && digits[6] == '0' && digits[7] == '0' && digits[8] == '0') { result = new ValidationResult<SsnValue>(false, default, ValidationError.CountryRule); return true; }
+        if (len != 9) { result = new ValidationResult<SsnValue>(false, default, ValidationError.Length); return false; }
+        if (digits[0] == '0' && digits[1] == '0' && digits[2] == '0') { result = new ValidationResult<SsnValue>(false, default, ValidationError.CountryRule); return false; }
+        int area = (digits[0] - '0') * 100 + (digits[1] - '0') * 10 + (digits[2] - '0');
+        if (area == 0 || area == 666 || area >= 900) { result = new ValidationResult<SsnValue>(false, default, ValidationError.CountryRule); return false; }
+        if (digits[3] == '0' && digits[4] == '0') { result = new ValidationResult<SsnValue>(false, default, ValidationError.CountryRule); return false; }
+        if (digits[5] == '0' && digits[6] == '0' && digits[7] == '0' && digits[8] == '0') { result = new ValidationResult<SsnValue>(false, default, ValidationError.CountryRule); return false; }
         result = new ValidationResult<SsnValue>(true, new SsnValue(new string(digits)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Telecom/Asn.cs
+++ b/src/Veritas/Telecom/Asn.cs
@@ -21,7 +21,7 @@ public static class Asn
     /// <summary>Attempts to validate the supplied input as an ASN.</summary>
     /// <param name="input">Candidate ASN to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<AsnValue> result)
     {
         if (uint.TryParse(input, NumberStyles.None, CultureInfo.InvariantCulture, out var value))
@@ -30,7 +30,7 @@ public static class Asn
             return true;
         }
         result = new ValidationResult<AsnValue>(false, default, ValidationError.Format);
-        return true;
+        return false;
     }
 
     /// <summary>Attempts to generate a random ASN into the provided buffer.</summary>

--- a/src/Veritas/Telecom/Iccid.cs
+++ b/src/Veritas/Telecom/Iccid.cs
@@ -21,7 +21,7 @@ public static class Iccid
     /// <summary>Attempts to validate the supplied input as an ICCID.</summary>
     /// <param name="input">Candidate code to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<IccidValue> result)
     {
         Span<char> digits = stackalloc char[20];
@@ -29,12 +29,12 @@ public static class Iccid
         foreach (var ch in input)
         {
             if (ch == ' ' || ch == '-') continue;
-            if (ch < '0' || ch > '9') { result = new ValidationResult<IccidValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= 20) { result = new ValidationResult<IccidValue>(false, default, ValidationError.Length); return true; }
+            if (ch < '0' || ch > '9') { result = new ValidationResult<IccidValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 20) { result = new ValidationResult<IccidValue>(false, default, ValidationError.Length); return false; }
             digits[len++] = ch;
         }
-        if (len < 19 || len > 20) { result = new ValidationResult<IccidValue>(false, default, ValidationError.Length); return true; }
-        if (!Luhn.Validate(digits[..len])) { result = new ValidationResult<IccidValue>(false, default, ValidationError.Checksum); return true; }
+        if (len < 19 || len > 20) { result = new ValidationResult<IccidValue>(false, default, ValidationError.Length); return false; }
+        if (!Luhn.Validate(digits[..len])) { result = new ValidationResult<IccidValue>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<IccidValue>(true, new IccidValue(new string(digits[..len])), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Telecom/Imei.cs
+++ b/src/Veritas/Telecom/Imei.cs
@@ -21,7 +21,7 @@ public static class Imei
     /// <summary>Attempts to validate the supplied input as an IMEI.</summary>
     /// <param name="input">Candidate code to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<ImeiValue> result)
     {
         Span<char> digits = stackalloc char[15];
@@ -29,12 +29,12 @@ public static class Imei
         foreach (var ch in input)
         {
             if (ch == ' ' || ch == '-') continue;
-            if (ch < '0' || ch > '9') { result = new ValidationResult<ImeiValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= 15) { result = new ValidationResult<ImeiValue>(false, default, ValidationError.Length); return true; }
+            if (ch < '0' || ch > '9') { result = new ValidationResult<ImeiValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 15) { result = new ValidationResult<ImeiValue>(false, default, ValidationError.Length); return false; }
             digits[len++] = ch;
         }
-        if (len != 15) { result = new ValidationResult<ImeiValue>(false, default, ValidationError.Length); return true; }
-        if (!Luhn.Validate(digits)) { result = new ValidationResult<ImeiValue>(false, default, ValidationError.Checksum); return true; }
+        if (len != 15) { result = new ValidationResult<ImeiValue>(false, default, ValidationError.Length); return false; }
+        if (!Luhn.Validate(digits)) { result = new ValidationResult<ImeiValue>(false, default, ValidationError.Checksum); return false; }
         result = new ValidationResult<ImeiValue>(true, new ImeiValue(new string(digits)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Telecom/Ipv4.cs
+++ b/src/Veritas/Telecom/Ipv4.cs
@@ -21,7 +21,7 @@ public static class Ipv4
     /// <summary>Attempts to validate the supplied input as an IPv4 address.</summary>
     /// <param name="input">Candidate address to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<Ipv4Value> result)
     {
         if (IPAddress.TryParse(input, out var addr) && addr.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
@@ -30,7 +30,7 @@ public static class Ipv4
             return true;
         }
         result = new ValidationResult<Ipv4Value>(false, default, ValidationError.Format);
-        return true;
+        return false;
     }
 }
 

--- a/src/Veritas/Telecom/Ipv6.cs
+++ b/src/Veritas/Telecom/Ipv6.cs
@@ -21,7 +21,7 @@ public static class Ipv6
     /// <summary>Attempts to validate the supplied input as an IPv6 address.</summary>
     /// <param name="input">Candidate address to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<Ipv6Value> result)
     {
         if (IPAddress.TryParse(input, out var addr) && addr.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6)
@@ -30,7 +30,7 @@ public static class Ipv6
             return true;
         }
         result = new ValidationResult<Ipv6Value>(false, default, ValidationError.Format);
-        return true;
+        return false;
     }
 }
 

--- a/src/Veritas/Telecom/Mac.cs
+++ b/src/Veritas/Telecom/Mac.cs
@@ -20,7 +20,7 @@ public static class Mac
     /// <summary>Attempts to validate the supplied input as a MAC address.</summary>
     /// <param name="input">Candidate address to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<MacValue> result)
     {
         Span<char> buf = stackalloc char[12];
@@ -29,11 +29,11 @@ public static class Mac
         {
             if (ch == '-' || ch == ':' || ch == '.') continue;
             char c = char.ToUpperInvariant(ch);
-            if (!Uri.IsHexDigit(c)) { result = new ValidationResult<MacValue>(false, default, ValidationError.Charset); return true; }
-            if (len >= 12) { result = new ValidationResult<MacValue>(false, default, ValidationError.Length); return true; }
+            if (!Uri.IsHexDigit(c)) { result = new ValidationResult<MacValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 12) { result = new ValidationResult<MacValue>(false, default, ValidationError.Length); return false; }
             buf[len++] = c;
         }
-        if (len != 12) { result = new ValidationResult<MacValue>(false, default, ValidationError.Length); return true; }
+        if (len != 12) { result = new ValidationResult<MacValue>(false, default, ValidationError.Length); return false; }
         result = new ValidationResult<MacValue>(true, new MacValue(new string(buf)), ValidationError.None);
         return true;
     }

--- a/src/Veritas/Telecom/Meid.cs
+++ b/src/Veritas/Telecom/Meid.cs
@@ -20,14 +20,14 @@ public static class Meid
     /// <summary>Attempts to validate the supplied input as a MEID.</summary>
     /// <param name="input">Candidate code to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<MeidValue> result)
     {
         Span<char> buf = stackalloc char[18];
         if (!Normalize(input, buf, out int len))
         {
             result = new ValidationResult<MeidValue>(false, default, ValidationError.Charset);
-            return true;
+            return false;
         }
         if (len == 14)
         {
@@ -37,7 +37,7 @@ public static class Meid
                 if (!Uri.IsHexDigit(c))
                 {
                     result = new ValidationResult<MeidValue>(false, default, ValidationError.Charset);
-                    return true;
+                    return false;
                 }
                 buf[i] = char.ToUpperInvariant(c);
             }
@@ -51,20 +51,20 @@ public static class Meid
                 if (!char.IsDigit(buf[i]))
                 {
                     result = new ValidationResult<MeidValue>(false, default, ValidationError.Charset);
-                    return true;
+                    return false;
                 }
             }
             int check = Luhn(buf[..17]);
             if (buf[17] != (char)('0' + check))
             {
                 result = new ValidationResult<MeidValue>(false, default, ValidationError.Checksum);
-                return true;
+                return false;
             }
             result = new ValidationResult<MeidValue>(true, new MeidValue(new string(buf[..18])), ValidationError.None);
             return true;
         }
         result = new ValidationResult<MeidValue>(false, default, ValidationError.Length);
-        return true;
+        return false;
     }
 
     /// <summary>Attempts to generate a random MEID into the provided buffer.</summary>

--- a/src/Veritas/Telecom/Oui.cs
+++ b/src/Veritas/Telecom/Oui.cs
@@ -20,7 +20,7 @@ public static class Oui
     /// <summary>Attempts to validate the supplied input as an OUI code.</summary>
     /// <param name="input">Candidate code to validate.</param>
     /// <param name="result">The validation outcome including the parsed value when valid.</param>
-    /// <returns><c>true</c> if validation executed; the <see cref="ValidationResult{T}.IsValid"/> property indicates success.</returns>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<OuiValue> result)
     {
         Span<char> buf = stackalloc char[6];
@@ -32,19 +32,19 @@ public static class Oui
             if (!Uri.IsHexDigit(c))
             {
                 result = new ValidationResult<OuiValue>(false, default, ValidationError.Charset);
-                return true;
+                return false;
             }
             if (len >= 6)
             {
                 result = new ValidationResult<OuiValue>(false, default, ValidationError.Length);
-                return true;
+                return false;
             }
             buf[len++] = c;
         }
         if (len != 6)
         {
             result = new ValidationResult<OuiValue>(false, default, ValidationError.Length);
-            return true;
+            return false;
         }
         result = new ValidationResult<OuiValue>(true, new OuiValue(new string(buf)), ValidationError.None);
         return true;

--- a/test/Veritas.Tests/Education/DoiTests.cs
+++ b/test/Veritas.Tests/Education/DoiTests.cs
@@ -9,7 +9,7 @@ public class DoiTests
     [InlineData("11.1000/182", false)]
     public void Validate(string input, bool expected)
     {
-        Doi.TryValidate(input, out var r);
+        Doi.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Education/IsmnTests.cs
+++ b/test/Veritas.Tests/Education/IsmnTests.cs
@@ -13,7 +13,7 @@ public class IsmnTests
     [InlineData("M12345", false)]
     public void Validate(string input, bool expected)
     {
-        Ismn.TryValidate(input, out var r);
+        Ismn.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -22,7 +22,7 @@ public class IsmnTests
     {
         Span<char> buffer = stackalloc char[13];
         Ismn.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Ismn.TryValidate(buffer[..written], out var r);
+        Ismn.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Education/IsniTests.cs
+++ b/test/Veritas.Tests/Education/IsniTests.cs
@@ -12,7 +12,7 @@ public class IsniTests
     [InlineData("000000012146438", false)]
     public void Validate(string input, bool expected)
     {
-        Isni.TryValidate(input, out var r);
+        Isni.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -21,7 +21,7 @@ public class IsniTests
     {
         Span<char> buffer = stackalloc char[16];
         Isni.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Isni.TryValidate(buffer[..written], out var r);
+        Isni.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Energy/DE/MaloTests.cs
+++ b/test/Veritas.Tests/Energy/DE/MaloTests.cs
@@ -10,7 +10,7 @@ public class MaloTests
     [InlineData("1234567890A", false)]
     public void Validate(string input, bool expected)
     {
-        Malo.TryValidate(input, out var result);
+        Malo.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Energy/DE/MeloTests.cs
+++ b/test/Veritas.Tests/Energy/DE/MeloTests.cs
@@ -10,7 +10,7 @@ public class MeloTests
     [InlineData("DEDGX4QK0NIAD8KYGGK09X58Y0Q4HLFE", false)]
     public void Validate(string input, bool expected)
     {
-        Melo.TryValidate(input, out var result);
+        Melo.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Energy/DE/ZpnTests.cs
+++ b/test/Veritas.Tests/Energy/DE/ZpnTests.cs
@@ -10,14 +10,14 @@ public class ZpnTests
         Span<char> buf = stackalloc char[40];
         Zpn.TryGenerate(buf, out var written).ShouldBeTrue();
         var s = new string(buf[..written]);
-        Zpn.TryValidate(s, out var result);
+        Zpn.TryValidate(s, out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 
     [Fact]
     public void InvalidPrefix()
     {
-        Zpn.TryValidate("XX123", out var result);
+        Zpn.TryValidate("XX123", out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Energy/ES/CupsTests.cs
+++ b/test/Veritas.Tests/Energy/ES/CupsTests.cs
@@ -12,7 +12,7 @@ public class CupsTests
     [InlineData("ES1234123456789012JY1Q", false)]
     public void Validate(string input, bool expected)
     {
-        Cups.TryValidate(input, out var result);
+        Cups.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -21,7 +21,7 @@ public class CupsTests
     {
         Span<char> buffer = stackalloc char[20];
         Cups.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Cups.TryValidate(buffer[..written], out var result);
+        Cups.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Energy/EicTests.cs
+++ b/test/Veritas.Tests/Energy/EicTests.cs
@@ -10,7 +10,7 @@ public class EicTests
     [InlineData("XAT000001234567", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Eic.TryValidate(input, out var result);
+        Eic.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Energy/FR/PrmTests.cs
+++ b/test/Veritas.Tests/Energy/FR/PrmTests.cs
@@ -10,7 +10,7 @@ public class PrmTests
     [InlineData("1234567890123A", false)]
     public void Validate(string input, bool expected)
     {
-        Prm.TryValidate(input, out var result);
+        Prm.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Energy/GB/MpanTests.cs
+++ b/test/Veritas.Tests/Energy/GB/MpanTests.cs
@@ -10,7 +10,7 @@ public class MpanTests
     [InlineData("1234567890124", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Mpan.TryValidate(input, out var result);
+        Mpan.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class MpanTests
     {
         Span<char> buffer = stackalloc char[13];
         Mpan.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Mpan.TryValidate(buffer[..written], out var result);
+        Mpan.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Energy/GB/MprnTests.cs
+++ b/test/Veritas.Tests/Energy/GB/MprnTests.cs
@@ -12,7 +12,7 @@ public class MprnTests
     [InlineData("12345A", false)]
     public void Validate(string input, bool expected)
     {
-        Mprn.TryValidate(input, out var result);
+        Mprn.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Energy/IT/PdrTests.cs
+++ b/test/Veritas.Tests/Energy/IT/PdrTests.cs
@@ -9,7 +9,7 @@ public class PdrTests
     [InlineData("1234567890123", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Pdr.TryValidate(input, out var result);
+        Pdr.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Energy/IT/PodTests.cs
+++ b/test/Veritas.Tests/Energy/IT/PodTests.cs
@@ -9,7 +9,7 @@ public class PodTests
     [InlineData("FR123ABCDE123456", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Pod.TryValidate(input, out var result);
+        Pod.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Energy/NL/EnergyEanTests.cs
+++ b/test/Veritas.Tests/Energy/NL/EnergyEanTests.cs
@@ -11,7 +11,7 @@ public class EnergyEanTests
     [InlineData("12345678901234567", false)]
     public void Validate(string input, bool expected)
     {
-        EnergyEan.TryValidate(input, out var result);
+        EnergyEan.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -20,7 +20,7 @@ public class EnergyEanTests
     {
         Span<char> buffer = stackalloc char[18];
         EnergyEan.TryGenerate(buffer, out var written).ShouldBeTrue();
-        EnergyEan.TryValidate(buffer[..written], out var result);
+        EnergyEan.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Finance/AbaRoutingTests.cs
+++ b/test/Veritas.Tests/Finance/AbaRoutingTests.cs
@@ -9,7 +9,7 @@ public class AbaRoutingTests
     [InlineData("111000026", false)]
     public void Validate_Works(string input, bool expected)
     {
-        AbaRouting.TryValidate(input, out var result);
+        AbaRouting.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Finance/BicTests.cs
+++ b/test/Veritas.Tests/Finance/BicTests.cs
@@ -9,7 +9,7 @@ public class BicTests
     [InlineData("DEUT12FF", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Bic.TryValidate(input, out var result);
+        Bic.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Finance/ClabeTests.cs
+++ b/test/Veritas.Tests/Finance/ClabeTests.cs
@@ -10,7 +10,7 @@ public class ClabeTests
     [InlineData("34931396232370974", false)]
     public void Validate(string input, bool expected)
     {
-        Clabe.TryValidate(input, out var result);
+        Clabe.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Finance/CusipTests.cs
+++ b/test/Veritas.Tests/Finance/CusipTests.cs
@@ -9,7 +9,7 @@ public class CusipTests
     [InlineData("037833101", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Cusip.TryValidate(input, out var result);
+        Cusip.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class CusipTests
     {
         Span<char> buffer = stackalloc char[9];
         Cusip.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Cusip.TryValidate(buffer[..written], out var result);
+        Cusip.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Finance/IbanTests.cs
+++ b/test/Veritas.Tests/Finance/IbanTests.cs
@@ -9,7 +9,7 @@ public class IbanTests
     [InlineData("FR14 2004 1010 0505 0001 3M02 607", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Iban.TryValidate(input, out var result);
+        Iban.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Finance/IsinTests.cs
+++ b/test/Veritas.Tests/Finance/IsinTests.cs
@@ -9,7 +9,7 @@ public class IsinTests
     [InlineData("US0378331006", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Isin.TryValidate(input, out var result);
+        Isin.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Finance/LeiTests.cs
+++ b/test/Veritas.Tests/Finance/LeiTests.cs
@@ -10,7 +10,7 @@ public class LeiTests
     [InlineData("PPOT00HKB2SNV4KKT", false)]
     public void Validate(string input, bool expected)
     {
-        Lei.TryValidate(input, out var result);
+        Lei.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Finance/MicTests.cs
+++ b/test/Veritas.Tests/Finance/MicTests.cs
@@ -9,7 +9,7 @@ public class MicTests
     [InlineData("ABC", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Mic.TryValidate(input, out var result);
+        Mic.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Finance/PanTests.cs
+++ b/test/Veritas.Tests/Finance/PanTests.cs
@@ -9,7 +9,7 @@ public class PanTests
     [InlineData("4111 1111 1111 1112", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Pan.TryValidate(input, out var result);
+        Pan.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Finance/RfTests.cs
+++ b/test/Veritas.Tests/Finance/RfTests.cs
@@ -10,7 +10,7 @@ public class RfTests
     [InlineData("RF00539007547034", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Rf.TryValidate(input, out var result);
+        Rf.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class RfTests
     {
         Span<char> buffer = stackalloc char[25];
         Rf.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Rf.TryValidate(buffer[..written], out var result);
+        Rf.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Finance/SedolTests.cs
+++ b/test/Veritas.Tests/Finance/SedolTests.cs
@@ -9,7 +9,7 @@ public class SedolTests
     [InlineData("B0YBKJ8", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Sedol.TryValidate(input, out var result);
+        Sedol.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class SedolTests
     {
         Span<char> buffer = stackalloc char[7];
         Sedol.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Sedol.TryValidate(buffer[..written], out var result);
+        Sedol.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Finance/WknTests.cs
+++ b/test/Veritas.Tests/Finance/WknTests.cs
@@ -9,7 +9,7 @@ public class WknTests
     [InlineData("M8QAUI1", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Wkn.TryValidate(input, out var result);
+        Wkn.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Healthcare/NhsNumberTests.cs
+++ b/test/Veritas.Tests/Healthcare/NhsNumberTests.cs
@@ -9,7 +9,7 @@ public class NhsNumberTests
     [InlineData("9434765918", false)]
     public void Validate(string input, bool expected)
     {
-        NhsNumber.TryValidate(input, out var r);
+        NhsNumber.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class NhsNumberTests
     {
         Span<char> buffer = stackalloc char[10];
         NhsNumber.TryGenerate(buffer, out var written).ShouldBeTrue();
-        NhsNumber.TryValidate(buffer[..written], out var r);
+        NhsNumber.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Healthcare/OrcidTests.cs
+++ b/test/Veritas.Tests/Healthcare/OrcidTests.cs
@@ -9,8 +9,8 @@ public class OrcidTests
     [InlineData("0000-0002-1825-0098", false)]
     public void Validate(string input, bool expected)
     {
-        Orcid.TryValidate(input, out var r);
-       r.IsValid.ShouldBe(expected);
+        Orcid.TryValidate(input, out var r).ShouldBe(expected);
+        r.IsValid.ShouldBe(expected);
     }
 
     [Fact]
@@ -18,7 +18,7 @@ public class OrcidTests
     {
         Span<char> buffer = stackalloc char[16];
         Orcid.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Orcid.TryValidate(buffer[..written], out var r);
+        Orcid.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Healthcare/Snomed/SctIdTests.cs
+++ b/test/Veritas.Tests/Healthcare/Snomed/SctIdTests.cs
@@ -11,7 +11,7 @@ public class SctIdTests
         Span<char> dst = stackalloc char[10];
         SctId.TryGenerate(10, new GenerationOptions { Seed = 42 }, dst, out var written).ShouldBeTrue();
         var s = new string(dst[..written]);
-        SctId.TryValidate(s, out var r);
+        SctId.TryValidate(s, out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 
@@ -24,7 +24,7 @@ public class SctIdTests
         // corrupt last digit
         char bad = s[^1] == '0' ? '1' : '0';
         var badStr = s[..^1] + bad;
-        SctId.TryValidate(badStr, out var r);
+        SctId.TryValidate(badStr, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/IP/Singapore/IpApplicationNumberTests.cs
+++ b/test/Veritas.Tests/IP/Singapore/IpApplicationNumberTests.cs
@@ -11,7 +11,7 @@ public class IpApplicationNumberTests
         Span<char> dst = stackalloc char[12];
         IpApplicationNumber.TryGenerate(new GenerationOptions { Seed = 99 }, dst, out var w).ShouldBeTrue();
         var s = new string(dst[..w]);
-        IpApplicationNumber.TryValidate(s, out var r);
+        IpApplicationNumber.TryValidate(s, out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 
@@ -22,7 +22,7 @@ public class IpApplicationNumberTests
         IpApplicationNumber.TryGenerate(new GenerationOptions { Seed = 100 }, dst, out var w).ShouldBeTrue();
         dst[11] = dst[11] == '0' ? '1' : '0';
         var s = new string(dst[..w]);
-        IpApplicationNumber.TryValidate(s, out var r);
+        IpApplicationNumber.TryValidate(s, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Identity/Base58CheckIdTests.cs
+++ b/test/Veritas.Tests/Identity/Base58CheckIdTests.cs
@@ -8,14 +8,14 @@ public class Base58CheckIdentityTests
     public void Validate_Known()
     {
         var s = "1BoatSLRHtKNngkdXEeobR76b53LETtpyT";
-        Base58Check.TryValidate(s, out var result);
+        Base58Check.TryValidate(s, out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 
     [Fact]
     public void Validate_Invalid()
     {
-        Base58Check.TryValidate("0OIl", out var result);
+        Base58Check.TryValidate("0OIl", out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Identity/Bcp47Tests.cs
+++ b/test/Veritas.Tests/Identity/Bcp47Tests.cs
@@ -9,7 +9,7 @@ public class Bcp47Tests
     [InlineData("en_us", false)]
     public void Validate(string tag, bool expected)
     {
-        Bcp47.TryValidate(tag, out var r);
+        Bcp47.TryValidate(tag, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Identity/DomainTests.cs
+++ b/test/Veritas.Tests/Identity/DomainTests.cs
@@ -9,7 +9,7 @@ public class DomainTests
     [InlineData("-bad.com", false)]
     public void Validate(string input, bool expected)
     {
-        Domain.TryValidate(input, out var r);
+        Domain.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Identity/EmailTests.cs
+++ b/test/Veritas.Tests/Identity/EmailTests.cs
@@ -9,7 +9,7 @@ public class EmailTests
     [InlineData("not-an-email", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Email.TryValidate(input, out var result);
+        Email.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Identity/EthereumTests.cs
+++ b/test/Veritas.Tests/Identity/EthereumTests.cs
@@ -10,7 +10,7 @@ public class EthereumTests
     [InlineData("zz709f2102306220921060314715629080e2fb77", false)]
     public void Validate(string input, bool expected)
     {
-        Ethereum.TryValidate(input, out var r);
+        Ethereum.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Identity/India/AadhaarTests.cs
+++ b/test/Veritas.Tests/Identity/India/AadhaarTests.cs
@@ -11,7 +11,7 @@ public class AadhaarTests
         Span<char> dst = stackalloc char[12];
         Aadhaar.TryGenerate(new GenerationOptions { Seed = 123 }, dst, out var written).ShouldBeTrue();
         var s = new string(dst[..written]);
-        Aadhaar.TryValidate(s, out var r);
+        Aadhaar.TryValidate(s, out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 
@@ -19,7 +19,7 @@ public class AadhaarTests
     [InlineData("123412341235", false)]
     public void Validate_Known(string input, bool expected)
     {
-        Aadhaar.TryValidate(input, out var r);
+        Aadhaar.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Identity/Israel/TeudatZehutTests.cs
+++ b/test/Veritas.Tests/Identity/Israel/TeudatZehutTests.cs
@@ -11,7 +11,7 @@ public class TeudatZehutTests
     {
         Span<char> buffer = stackalloc char[9];
         TeudatZehut.TryGenerate(buffer, out var written).ShouldBeTrue();
-        TeudatZehut.TryValidate(buffer[..written], out var result);
+        TeudatZehut.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 
@@ -21,7 +21,7 @@ public class TeudatZehutTests
         Span<char> buffer = stackalloc char[9];
         TeudatZehut.TryGenerate(new GenerationOptions { Seed = 6 }, buffer, out var w).ShouldBeTrue();
         buffer[w - 1] = buffer[w - 1] == '0' ? '1' : '0';
-        TeudatZehut.TryValidate(buffer[..w], out var result);
+        TeudatZehut.TryValidate(buffer[..w], out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Identity/KsuidTests.cs
+++ b/test/Veritas.Tests/Identity/KsuidTests.cs
@@ -10,7 +10,7 @@ public class KsuidTests
     [InlineData("0ujtsYcgvSTl8PAuAdqWYSMnLO", false)]
     public void Validate(string input, bool expected)
     {
-        Ksuid.TryValidate(input, out var r);
+        Ksuid.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -20,7 +20,7 @@ public class KsuidTests
         Span<char> buf = stackalloc char[27];
         Ksuid.TryGenerate(default, buf, out var w).ShouldBeTrue();
         w.ShouldBe(27);
-        Ksuid.TryValidate(new string(buf), out var r);
+        Ksuid.TryValidate(new string(buf), out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Identity/Luxembourg/NationalIdTests.cs
+++ b/test/Veritas.Tests/Identity/Luxembourg/NationalIdTests.cs
@@ -11,7 +11,7 @@ public class NationalIdTests
         Span<char> dst = stackalloc char[13];
         NationalId.TryGenerate(new GenerationOptions { Seed = 7 }, dst, out var w).ShouldBeTrue();
         var s = new string(dst[..w]);
-        NationalId.TryValidate(s, out var r);
+        NationalId.TryValidate(s, out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 
@@ -22,7 +22,7 @@ public class NationalIdTests
         NationalId.TryGenerate(new GenerationOptions { Seed = 8 }, dst, out var w).ShouldBeTrue();
         dst[11] = dst[11] == '0' ? '1' : '0';
         var s = new string(dst[..w]);
-        NationalId.TryValidate(s, out var r);
+        NationalId.TryValidate(s, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Identity/Mexico/CurpTests.cs
+++ b/test/Veritas.Tests/Identity/Mexico/CurpTests.cs
@@ -10,7 +10,7 @@ public class CurpTests
     {
         Span<char> buffer = stackalloc char[18];
         Curp.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Curp.TryValidate(buffer[..written], out var result);
+        Curp.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 
@@ -20,7 +20,7 @@ public class CurpTests
         Span<char> buffer = stackalloc char[18];
         Curp.TryGenerate(new GenerationOptions { Seed = 3 }, buffer, out var w).ShouldBeTrue();
         buffer[w - 1] = buffer[w - 1] == '0' ? '1' : '0';
-        Curp.TryValidate(buffer[..w], out var result);
+        Curp.TryValidate(buffer[..w], out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Identity/NanoIdTests.cs
+++ b/test/Veritas.Tests/Identity/NanoIdTests.cs
@@ -10,7 +10,7 @@ public class NanoIdTests
     [InlineData("0123456789ABCDEFGH#K", false)]
     public void Validate(string input, bool expected)
     {
-        NanoId.TryValidate(input, out var r);
+        NanoId.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class NanoIdTests
     {
         Span<char> buffer = stackalloc char[21];
         NanoId.TryGenerate(buffer, out var written).ShouldBeTrue();
-        NanoId.TryValidate(buffer[..written], out var r);
+        NanoId.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Identity/PhoneTests.cs
+++ b/test/Veritas.Tests/Identity/PhoneTests.cs
@@ -9,7 +9,7 @@ public class PhoneTests
     [InlineData("123-abc", false)]
     public void Validate(string input, bool expected)
     {
-        Phone.TryValidate(input, out var r);
+        Phone.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Identity/SouthAfrica/NationalIdTests.cs
+++ b/test/Veritas.Tests/Identity/SouthAfrica/NationalIdTests.cs
@@ -10,7 +10,7 @@ public class SouthAfricaNationalIdTests
     {
         Span<char> buffer = stackalloc char[13];
         NationalId.TryGenerate(buffer, out var written).ShouldBeTrue();
-        NationalId.TryValidate(buffer[..written], out var result);
+        NationalId.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 
@@ -20,7 +20,7 @@ public class SouthAfricaNationalIdTests
         Span<char> buffer = stackalloc char[13];
         NationalId.TryGenerate(new GenerationOptions { Seed = 5 }, buffer, out var w).ShouldBeTrue();
         buffer[w - 1] = buffer[w - 1] == '0' ? '1' : '0';
-        NationalId.TryValidate(buffer[..w], out var result);
+        NationalId.TryValidate(buffer[..w], out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Identity/UlidTests.cs
+++ b/test/Veritas.Tests/Identity/UlidTests.cs
@@ -10,7 +10,7 @@ public class UlidTests
     [InlineData("01ARZ3NDEKTSV4RRFFQ69G5FIV", false)]
     public void Validate(string input, bool expected)
     {
-        Ulid.TryValidate(input, out var r);
+        Ulid.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class UlidTests
     {
         Span<char> buffer = stackalloc char[26];
         Ulid.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Ulid.TryValidate(buffer[..written], out var r);
+        Ulid.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Identity/UuidTests.cs
+++ b/test/Veritas.Tests/Identity/UuidTests.cs
@@ -8,7 +8,7 @@ public class UuidTests
     public void Validate_Works()
     {
         var guid = System.Guid.NewGuid().ToString();
-        Uuid.TryValidate(guid, out var result);
+        Uuid.TryValidate(guid, out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Logistics/AwbTests.cs
+++ b/test/Veritas.Tests/Logistics/AwbTests.cs
@@ -12,7 +12,7 @@ public class AwbTests
     [InlineData("1231234567", false)]
     public void Validate(string input, bool expected)
     {
-        Awb.TryValidate(input, out var r);
+        Awb.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -21,7 +21,7 @@ public class AwbTests
     {
         Span<char> buffer = stackalloc char[11];
         Awb.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Awb.TryValidate(buffer[..written], out var r);
+        Awb.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Logistics/GlnTests.cs
+++ b/test/Veritas.Tests/Logistics/GlnTests.cs
@@ -10,7 +10,7 @@ public class GlnTests
     [InlineData("1234567890123", false)]
     public void Validate(string input, bool expected)
     {
-        Gln.TryValidate(input, out var r);
+        Gln.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class GlnTests
     {
         Span<char> buffer = stackalloc char[13];
         Gln.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Gln.TryValidate(buffer[..written], out var r);
+        Gln.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Logistics/GtinTests.cs
+++ b/test/Veritas.Tests/Logistics/GtinTests.cs
@@ -10,7 +10,7 @@ public class GtinTests
     [InlineData("4006381333932", false)]
     public void Validate(string input, bool expected)
     {
-        Gtin.TryValidate(input, out var r);
+        Gtin.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class GtinTests
     {
         Span<char> buffer = stackalloc char[13];
         Gtin.TryGenerate(13, buffer, out var written).ShouldBeTrue();
-        Gtin.TryValidate(buffer[..written], out var r);
+        Gtin.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Logistics/ImoTests.cs
+++ b/test/Veritas.Tests/Logistics/ImoTests.cs
@@ -12,7 +12,7 @@ public class ImoTests
     [InlineData("123456", false)]
     public void Validate(string input, bool expected)
     {
-        Imo.TryValidate(input, out var r);
+        Imo.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -21,7 +21,7 @@ public class ImoTests
     {
         Span<char> buffer = stackalloc char[10];
         Imo.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Imo.TryValidate(buffer[..written], out var r);
+        Imo.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Logistics/Iso6346Tests.cs
+++ b/test/Veritas.Tests/Logistics/Iso6346Tests.cs
@@ -9,7 +9,7 @@ public class Iso6346Tests
     [InlineData("MSCU6639871", false)]
     public void Validate(string input, bool expected)
     {
-        Iso6346.TryValidate(input, out var r);
+        Iso6346.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Logistics/SsccTests.cs
+++ b/test/Veritas.Tests/Logistics/SsccTests.cs
@@ -10,7 +10,7 @@ public class SsccTests
     [InlineData("123456789012345671", false)]
     public void Validate(string input, bool expected)
     {
-        Sscc.TryValidate(input, out var r);
+        Sscc.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class SsccTests
     {
         Span<char> buffer = stackalloc char[18];
         Sscc.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Sscc.TryValidate(buffer[..written], out var r);
+        Sscc.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Logistics/VinTests.cs
+++ b/test/Veritas.Tests/Logistics/VinTests.cs
@@ -9,7 +9,7 @@ public class VinTests
     [InlineData("1HGCM82633A004353", false)]
     public void Validate(string input, bool expected)
     {
-        Vin.TryValidate(input, out var r);
+        Vin.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Media/Isbn10Tests.cs
+++ b/test/Veritas.Tests/Media/Isbn10Tests.cs
@@ -10,7 +10,7 @@ public class Isbn10Tests
     [InlineData("0306406153", false)]
     public void Validate(string input, bool expected)
     {
-        Isbn10.TryValidate(input, out var r);
+        Isbn10.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class Isbn10Tests
     {
         Span<char> buffer = stackalloc char[10];
         Isbn10.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Isbn10.TryValidate(buffer[..written], out var r);
+        Isbn10.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Media/Isbn13Tests.cs
+++ b/test/Veritas.Tests/Media/Isbn13Tests.cs
@@ -10,7 +10,7 @@ public class Isbn13Tests
     [InlineData("9780306406158", false)]
     public void Validate(string input, bool expected)
     {
-        Isbn13.TryValidate(input, out var r);
+        Isbn13.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class Isbn13Tests
     {
         Span<char> buffer = stackalloc char[13];
         Isbn13.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Isbn13.TryValidate(buffer[..written], out var r);
+        Isbn13.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Media/IsrcTests.cs
+++ b/test/Veritas.Tests/Media/IsrcTests.cs
@@ -11,7 +11,7 @@ public class IsrcTests
     [InlineData("USRC1760783", false)]
     public void Validate(string input, bool expected)
     {
-        Isrc.TryValidate(input, out var r);
+        Isrc.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Media/IssnTests.cs
+++ b/test/Veritas.Tests/Media/IssnTests.cs
@@ -10,7 +10,7 @@ public class IssnTests
     [InlineData("0378-5954", false)]
     public void Validate(string input, bool expected)
     {
-        Issn.TryValidate(input, out var r);
+        Issn.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class IssnTests
     {
         Span<char> buffer = stackalloc char[8];
         Issn.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Issn.TryValidate(buffer[..written], out var r);
+        Issn.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Mod11Tests.cs
+++ b/test/Veritas.Tests/Mod11Tests.cs
@@ -9,7 +9,7 @@ public class Mod11Tests
     public void ComputeMod11_Works()
     {
         var digits = "12345".AsSpan();
-        int[] weights = {5,4,3,2,1};
+        int[] weights = { 5, 4, 3, 2, 1 };
         Mod11.ComputeMod11(digits, weights).ShouldBe(2);
     }
 }

--- a/test/Veritas.Tests/Tax/AR/CuitTests.cs
+++ b/test/Veritas.Tests/Tax/AR/CuitTests.cs
@@ -10,7 +10,7 @@ public class CuitTests
     [InlineData("20-12345678-5", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Cuit.TryValidate(input, out var result);
+        Cuit.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class CuitTests
     {
         Span<char> buffer = stackalloc char[11];
         Cuit.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Cuit.TryValidate(buffer[..written], out var result);
+        Cuit.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/AT/UidTests.cs
+++ b/test/Veritas.Tests/Tax/AT/UidTests.cs
@@ -29,7 +29,7 @@ public class UidTests
     [InlineData("ATU12345A75")]
     public void ValidateBad(string input)
     {
-        Uid.TryValidate(input, out var r).ShouldBeTrue();
+        Uid.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/AU/AbnTests.cs
+++ b/test/Veritas.Tests/Tax/AU/AbnTests.cs
@@ -9,7 +9,7 @@ public class AbnTests
     [InlineData("51824753557", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Abn.TryValidate(input, out var result);
+        Abn.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class AbnTests
     {
         Span<char> buffer = stackalloc char[11];
         Abn.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Abn.TryValidate(buffer[..written], out var result);
+        Abn.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/AU/TfnTests.cs
+++ b/test/Veritas.Tests/Tax/AU/TfnTests.cs
@@ -9,7 +9,7 @@ public class TfnTests
     [InlineData("123456789", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Tfn.TryValidate(input, out var result);
+        Tfn.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class TfnTests
     {
         Span<char> buffer = stackalloc char[9];
         Tfn.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Tfn.TryValidate(buffer[..written], out var result);
+        Tfn.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/BE/NnTests.cs
+++ b/test/Veritas.Tests/Tax/BE/NnTests.cs
@@ -10,7 +10,7 @@ public class NnTests
     [InlineData("90010100124", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Nn.TryValidate(input, out var result);
+        Nn.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class NnTests
     {
         Span<char> buffer = stackalloc char[11];
         Nn.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Nn.TryValidate(buffer[..written], out var result);
+        Nn.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/BG/EgnTests.cs
+++ b/test/Veritas.Tests/Tax/BG/EgnTests.cs
@@ -29,7 +29,7 @@ public class EgnTests
     [InlineData("abcdefghij")]
     public void ValidateBad(string input)
     {
-        Egn.TryValidate(input, out var r).ShouldBeTrue();
+        Egn.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/BR/CnpjTests.cs
+++ b/test/Veritas.Tests/Tax/BR/CnpjTests.cs
@@ -10,7 +10,7 @@ public class CnpjTests
     [InlineData("04.252.011/0001-11", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Cnpj.TryValidate(input, out var result);
+        Cnpj.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class CnpjTests
     {
         Span<char> buffer = stackalloc char[14];
         Cnpj.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Cnpj.TryValidate(buffer[..written], out var result);
+        Cnpj.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/BR/CpfTests.cs
+++ b/test/Veritas.Tests/Tax/BR/CpfTests.cs
@@ -10,7 +10,7 @@ public class CpfTests
     [InlineData("111.444.777-36", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Cpf.TryValidate(input, out var result);
+        Cpf.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class CpfTests
     {
         Span<char> buffer = stackalloc char[11];
         Cpf.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Cpf.TryValidate(buffer[..written], out var result);
+        Cpf.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/CA/BnTests.cs
+++ b/test/Veritas.Tests/Tax/CA/BnTests.cs
@@ -8,9 +8,9 @@ public class BnTests
     public void Validate_Works()
     {
         var valid = "660487646";
-        Bn.TryValidate(valid, out var result);
+        Bn.TryValidate(valid, out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
-        Bn.TryValidate(valid[..8] + '0', out var invalid);
+        Bn.TryValidate(valid[..8] + '0', out var invalid).ShouldBeFalse();
         invalid.IsValid.ShouldBeFalse();
     }
 
@@ -19,7 +19,7 @@ public class BnTests
     {
         Span<char> buffer = stackalloc char[9];
         Bn.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Bn.TryValidate(buffer[..written], out var result);
+        Bn.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/CA/SinTests.cs
+++ b/test/Veritas.Tests/Tax/CA/SinTests.cs
@@ -9,7 +9,7 @@ public class SinTests
     [InlineData("046454287", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Sin.TryValidate(input, out var result);
+        Sin.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class SinTests
     {
         Span<char> buffer = stackalloc char[9];
         Sin.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Sin.TryValidate(buffer[..written], out var result);
+        Sin.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/CH/AhvTests.cs
+++ b/test/Veritas.Tests/Tax/CH/AhvTests.cs
@@ -29,7 +29,7 @@ public class AhvTests
     [InlineData("756.9217.0769.85a")]
     public void ValidateBad(string input)
     {
-        Ahv.TryValidate(input, out var r).ShouldBeTrue();
+        Ahv.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/CH/UidTests.cs
+++ b/test/Veritas.Tests/Tax/CH/UidTests.cs
@@ -30,7 +30,7 @@ public class UidTests
     [InlineData("CHE100155709XYZ")]
     public void ValidateBad(string input)
     {
-        Uid.TryValidate(input, out var r).ShouldBeTrue();
+        Uid.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/CL/RutTests.cs
+++ b/test/Veritas.Tests/Tax/CL/RutTests.cs
@@ -10,7 +10,7 @@ public class RutTests
     [InlineData("12.345.678-4", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Rut.TryValidate(input, out var result);
+        Rut.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class RutTests
     {
         Span<char> buffer = stackalloc char[9];
         Rut.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Rut.TryValidate(buffer[..written], out var result);
+        Rut.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/CN/UsccTests.cs
+++ b/test/Veritas.Tests/Tax/CN/UsccTests.cs
@@ -8,9 +8,9 @@ public class UsccTests
     public void Validate_Works()
     {
         const string valid = "UCQWD18YGFCXRT9YFY";
-        Uscc.TryValidate(valid, out var result);
+        Uscc.TryValidate(valid, out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
-        Uscc.TryValidate(valid[..17] + '0', out var invalid);
+        Uscc.TryValidate(valid[..17] + '0', out var invalid).ShouldBeFalse();
         invalid.IsValid.ShouldBeFalse();
     }
 
@@ -19,7 +19,7 @@ public class UsccTests
     {
         Span<char> buffer = stackalloc char[18];
         Uscc.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Uscc.TryValidate(buffer[..written], out var result);
+        Uscc.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/CO/NitTests.cs
+++ b/test/Veritas.Tests/Tax/CO/NitTests.cs
@@ -29,7 +29,7 @@ public class NitTests
     [InlineData("abcdefghij")]
     public void ValidateBad(string input)
     {
-        Nit.TryValidate(input, out var r).ShouldBeTrue();
+        Nit.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/CZ/RodneCisloTests.cs
+++ b/test/Veritas.Tests/Tax/CZ/RodneCisloTests.cs
@@ -9,7 +9,7 @@ public class CzRodneCisloTests
     [InlineData("850712/1239", false)]
     public void Validate_Works(string input, bool expected)
     {
-        RodneCislo.TryValidate(input, out var result);
+        RodneCislo.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class CzRodneCisloTests
     {
         Span<char> buffer = stackalloc char[10];
         RodneCislo.TryGenerate(buffer, out var written).ShouldBeTrue();
-        RodneCislo.TryValidate(buffer[..written], out var result);
+        RodneCislo.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/DE/IdNrTests.cs
+++ b/test/Veritas.Tests/Tax/DE/IdNrTests.cs
@@ -10,7 +10,7 @@ public class IdNrTests
     [InlineData("36574261890", false)]
     public void Validate(string input, bool expected)
     {
-        IdNr.TryValidate(input, out var result);
+        IdNr.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class IdNrTests
     {
         Span<char> buffer = stackalloc char[11];
         IdNr.TryGenerate(buffer, out var written).ShouldBeTrue();
-        IdNr.TryValidate(buffer[..written], out var result);
+        IdNr.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/DE/UstIdNrTests.cs
+++ b/test/Veritas.Tests/Tax/DE/UstIdNrTests.cs
@@ -11,7 +11,7 @@ public class UstIdNrTests
     [InlineData("136695978", false)]
     public void Validate(string input, bool expected)
     {
-        UstIdNr.TryValidate(input, out var result);
+        UstIdNr.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -20,7 +20,7 @@ public class UstIdNrTests
     {
         Span<char> buffer = stackalloc char[9];
         UstIdNr.TryGenerate(buffer, out var written).ShouldBeTrue();
-        UstIdNr.TryValidate(buffer[..written], out var result);
+        UstIdNr.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/DK/CprTests.cs
+++ b/test/Veritas.Tests/Tax/DK/CprTests.cs
@@ -29,7 +29,7 @@ public class CprTests
     [InlineData("abcdefghij")]
     public void ValidateBad(string input)
     {
-        Cpr.TryValidate(input, out var r).ShouldBeTrue();
+        Cpr.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/EE/IsikukoodTests.cs
+++ b/test/Veritas.Tests/Tax/EE/IsikukoodTests.cs
@@ -29,7 +29,7 @@ public class IsikukoodTests
     [InlineData("abcdefghijk")]
     public void ValidateBad(string input)
     {
-        Isikukood.TryValidate(input, out var r).ShouldBeTrue();
+        Isikukood.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/ES/CifTests.cs
+++ b/test/Veritas.Tests/Tax/ES/CifTests.cs
@@ -10,14 +10,14 @@ public class CifTests
     [InlineData("B12345678", false)]
     public void Validate(string input, bool expected)
     {
-        Cif.TryValidate(input, out var result);
+        Cif.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
     [Theory, AutoData]
     public void RandomString_IsInvalid(string random)
     {
-        Cif.TryValidate(random, out var result);
+        Cif.TryValidate(random, out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/ES/NieTests.cs
+++ b/test/Veritas.Tests/Tax/ES/NieTests.cs
@@ -10,14 +10,14 @@ public class NieTests
     [InlineData("X2482300A", false)]
     public void Validate(string input, bool expected)
     {
-        Nie.TryValidate(input, out var result);
+        Nie.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
     [Theory, AutoData]
     public void RandomString_IsInvalid(string random)
     {
-        Nie.TryValidate(random, out var result);
+        Nie.TryValidate(random, out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/ES/NifTests.cs
+++ b/test/Veritas.Tests/Tax/ES/NifTests.cs
@@ -10,14 +10,14 @@ public class NifTests
     [InlineData("12345678A", false)]
     public void Validate(string input, bool expected)
     {
-        Nif.TryValidate(input, out var result);
+        Nif.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
     [Theory, AutoData]
     public void RandomString_IsInvalid(string random)
     {
-        Nif.TryValidate(random, out var result);
+        Nif.TryValidate(random, out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/FI/HetuTests.cs
+++ b/test/Veritas.Tests/Tax/FI/HetuTests.cs
@@ -10,7 +10,7 @@ public class HetuTests
     [InlineData("131052-308U", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Hetu.TryValidate(input, out var result);
+        Hetu.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class HetuTests
     {
         Span<char> buffer = stackalloc char[11];
         Hetu.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Hetu.TryValidate(buffer[..written], out var result);
+        Hetu.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/FR/SirenTests.cs
+++ b/test/Veritas.Tests/Tax/FR/SirenTests.cs
@@ -9,7 +9,7 @@ public class SirenTests
     [InlineData("552100555", false)]
     public void Validate(string input, bool expected)
     {
-        Siren.TryValidate(input, out var r);
+        Siren.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/FR/SiretTests.cs
+++ b/test/Veritas.Tests/Tax/FR/SiretTests.cs
@@ -9,7 +9,7 @@ public class SiretTests
     [InlineData("55210055400014", false)]
     public void Validate(string input, bool expected)
     {
-        Siret.TryValidate(input, out var r);
+        Siret.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/FR/VatTests.cs
+++ b/test/Veritas.Tests/Tax/FR/VatTests.cs
@@ -10,14 +10,14 @@ public class FrVatTests
     [InlineData("FR45 732829320", false)]
     public void Validate(string input, bool expected)
     {
-        Vat.TryValidate(input, out var result);
+        Vat.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
     [Theory, AutoData]
     public void RandomString_IsInvalid(string random)
     {
-        Vat.TryValidate(random, out var result);
+        Vat.TryValidate(random, out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/GR/AfmTests.cs
+++ b/test/Veritas.Tests/Tax/GR/AfmTests.cs
@@ -10,7 +10,7 @@ public class AfmTests
     [InlineData("291417770", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Afm.TryValidate(input, out var result);
+        Afm.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class AfmTests
     {
         Span<char> buffer = stackalloc char[9];
         Afm.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Afm.TryValidate(buffer[..written], out var result);
+        Afm.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/HR/OibTests.cs
+++ b/test/Veritas.Tests/Tax/HR/OibTests.cs
@@ -9,7 +9,7 @@ public class HrOibTests
     [InlineData("12345678904", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Oib.TryValidate(input, out var result);
+        Oib.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class HrOibTests
     {
         Span<char> buffer = stackalloc char[11];
         Oib.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Oib.TryValidate(buffer[..written], out var result);
+        Oib.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/IE/PpsnTests.cs
+++ b/test/Veritas.Tests/Tax/IE/PpsnTests.cs
@@ -10,7 +10,7 @@ public class PpsnTests
     [InlineData("1234567WA", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Ppsn.TryValidate(input, out var result);
+        Ppsn.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class PpsnTests
     {
         Span<char> buffer = stackalloc char[9];
         Ppsn.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Ppsn.TryValidate(buffer[..written], out var result);
+        Ppsn.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/IN/InPanTests.cs
+++ b/test/Veritas.Tests/Tax/IN/InPanTests.cs
@@ -9,7 +9,7 @@ public class InPanTests
     [InlineData("ABCDE1234A", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Pan.TryValidate(input, out var result);
+        Pan.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class InPanTests
     {
         Span<char> buffer = stackalloc char[10];
         Pan.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Pan.TryValidate(buffer[..written], out var result);
+        Pan.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/IS/KennitalaTests.cs
+++ b/test/Veritas.Tests/Tax/IS/KennitalaTests.cs
@@ -29,7 +29,7 @@ public class KennitalaTests
     [InlineData("abcdefghij")]
     public void ValidateBad(string input)
     {
-        Kennitala.TryValidate(input, out var r).ShouldBeTrue();
+        Kennitala.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/IT/CodiceFiscaleTests.cs
+++ b/test/Veritas.Tests/Tax/IT/CodiceFiscaleTests.cs
@@ -10,7 +10,7 @@ public class CodiceFiscaleTests
     {
         Span<char> buffer = stackalloc char[16];
         CodiceFiscale.TryGenerate(buffer, out var written).ShouldBeTrue();
-        CodiceFiscale.TryValidate(buffer[..written], out var result);
+        CodiceFiscale.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 
@@ -20,7 +20,7 @@ public class CodiceFiscaleTests
         Span<char> buffer = stackalloc char[16];
         CodiceFiscale.TryGenerate(new GenerationOptions { Seed = 1 }, buffer, out var w).ShouldBeTrue();
         buffer[w - 1] = buffer[w - 1] == 'A' ? 'B' : 'A';
-        CodiceFiscale.TryValidate(buffer[..w], out var result);
+        CodiceFiscale.TryValidate(buffer[..w], out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/IT/PivaTests.cs
+++ b/test/Veritas.Tests/Tax/IT/PivaTests.cs
@@ -10,14 +10,14 @@ public class PivaTests
     [InlineData("01114601007", false)]
     public void Validate(string input, bool expected)
     {
-        Piva.TryValidate(input, out var result);
+        Piva.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
     [Theory, AutoData]
     public void RandomString_IsInvalid(string random)
     {
-        Piva.TryValidate(random, out var result);
+        Piva.TryValidate(random, out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/LT/AsmensKodasTests.cs
+++ b/test/Veritas.Tests/Tax/LT/AsmensKodasTests.cs
@@ -29,7 +29,7 @@ public class AsmensKodasTests
     [InlineData("abcdefghijk")]
     public void ValidateBad(string input)
     {
-        AsmensKodas.TryValidate(input, out var r).ShouldBeTrue();
+        AsmensKodas.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/LV/PersonasKodsTests.cs
+++ b/test/Veritas.Tests/Tax/LV/PersonasKodsTests.cs
@@ -29,7 +29,7 @@ public class PersonasKodsTests
     [InlineData("abcdefghijk")]
     public void ValidateBad(string input)
     {
-        PersonasKods.TryValidate(input, out var r).ShouldBeTrue();
+        PersonasKods.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/MX/RfcTests.cs
+++ b/test/Veritas.Tests/Tax/MX/RfcTests.cs
@@ -10,7 +10,7 @@ public class RfcTests
     {
         Span<char> buffer = stackalloc char[13];
         Rfc.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Rfc.TryValidate(buffer[..written], out var result);
+        Rfc.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 
@@ -20,7 +20,7 @@ public class RfcTests
         Span<char> buffer = stackalloc char[13];
         Rfc.TryGenerate(new GenerationOptions { Seed = 2 }, buffer, out var w).ShouldBeTrue();
         buffer[w - 1] = buffer[w - 1] == '0' ? '1' : '0';
-        Rfc.TryValidate(buffer[..w], out var result);
+        Rfc.TryValidate(buffer[..w], out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/NL/BsnTests.cs
+++ b/test/Veritas.Tests/Tax/NL/BsnTests.cs
@@ -10,14 +10,14 @@ public class BsnTests
     [InlineData("100000008", false)]
     public void Validate(string input, bool expected)
     {
-        Bsn.TryValidate(input, out var result);
+        Bsn.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
     [Theory, AutoData]
     public void RandomString_IsInvalid(string random)
     {
-        Bsn.TryValidate(random, out var result);
+        Bsn.TryValidate(random, out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/NL/BtwTests.cs
+++ b/test/Veritas.Tests/Tax/NL/BtwTests.cs
@@ -10,14 +10,14 @@ public class BtwTests
     [InlineData("100000003B01", false)]
     public void Validate(string input, bool expected)
     {
-        Btw.TryValidate(input, out var result);
+        Btw.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
     [Theory, AutoData]
     public void RandomString_IsInvalid(string random)
     {
-        Btw.TryValidate(random, out var result);
+        Btw.TryValidate(random, out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/NO/FodselsnummerTests.cs
+++ b/test/Veritas.Tests/Tax/NO/FodselsnummerTests.cs
@@ -9,7 +9,7 @@ public class NoFodselsnummerTests
     [InlineData("12078586469", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Fodselsnummer.TryValidate(input, out var result);
+        Fodselsnummer.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class NoFodselsnummerTests
     {
         Span<char> buffer = stackalloc char[11];
         Fodselsnummer.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Fodselsnummer.TryValidate(buffer[..written], out var result);
+        Fodselsnummer.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/NO/KidTests.cs
+++ b/test/Veritas.Tests/Tax/NO/KidTests.cs
@@ -11,7 +11,7 @@ public class NoKidTests
     [InlineData("12344", KidVariant.Mod11, false)]
     public void Validate_Works(string input, KidVariant variant, bool expected)
     {
-        Kid.TryValidate(input, variant, out var result);
+        Kid.TryValidate(input, variant, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -20,7 +20,7 @@ public class NoKidTests
     {
         Span<char> buffer = stackalloc char[5];
         Kid.TryGenerate(KidVariant.Mod10, 5, buffer, out var written).ShouldBeTrue();
-        Kid.TryValidate(buffer[..written], KidVariant.Mod10, out var result);
+        Kid.TryValidate(buffer[..written], KidVariant.Mod10, out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 
@@ -29,7 +29,7 @@ public class NoKidTests
     {
         Span<char> buffer = stackalloc char[5];
         Kid.TryGenerate(KidVariant.Mod11, 5, buffer, out var written).ShouldBeTrue();
-        Kid.TryValidate(buffer[..written], KidVariant.Mod11, out var result);
+        Kid.TryValidate(buffer[..written], KidVariant.Mod11, out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/NZ/IrdTests.cs
+++ b/test/Veritas.Tests/Tax/NZ/IrdTests.cs
@@ -9,7 +9,7 @@ public class IrdTests
     [InlineData("49091851", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Ird.TryValidate(input, out var result);
+        Ird.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/PE/RucTests.cs
+++ b/test/Veritas.Tests/Tax/PE/RucTests.cs
@@ -29,7 +29,7 @@ public class RucTests
     [InlineData("abcdefghijk")]
     public void ValidateBad(string input)
     {
-        Ruc.TryValidate(input, out var r).ShouldBeTrue();
+        Ruc.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/PL/NipTests.cs
+++ b/test/Veritas.Tests/Tax/PL/NipTests.cs
@@ -9,7 +9,7 @@ public class NipTests
     [InlineData("6111780028", false)]
     public void Validate(string input, bool expected)
     {
-        Nip.TryValidate(input, out var result);
+        Nip.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/PL/PeselTests.cs
+++ b/test/Veritas.Tests/Tax/PL/PeselTests.cs
@@ -9,7 +9,7 @@ public class PeselTests
     [InlineData("44051401358", false)]
     public void Validate(string input, bool expected)
     {
-        Pesel.TryValidate(input, out var result);
+        Pesel.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/PL/RegonTests.cs
+++ b/test/Veritas.Tests/Tax/PL/RegonTests.cs
@@ -11,7 +11,7 @@ public class RegonTests
     [InlineData("12345678901235", false)]
     public void Validate(string input, bool expected)
     {
-        Regon.TryValidate(input, out var result);
+        Regon.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/PT/NifTests.cs
+++ b/test/Veritas.Tests/Tax/PT/NifTests.cs
@@ -10,7 +10,7 @@ public class PtNifTests
     [InlineData("166048764", false)]
     public void Validate_Works(string input, bool expected)
     {
-        Nif.TryValidate(input, out var result);
+        Nif.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class PtNifTests
     {
         Span<char> buffer = stackalloc char[9];
         Nif.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Nif.TryValidate(buffer[..written], out var result);
+        Nif.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/RO/CnpTests.cs
+++ b/test/Veritas.Tests/Tax/RO/CnpTests.cs
@@ -30,7 +30,7 @@ public class CnpTests
     [InlineData("abcdefghijklm")]
     public void ValidateBad(string input)
     {
-        Cnp.TryValidate(input, out var r).ShouldBeTrue();
+        Cnp.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/RS/JmbgTests.cs
+++ b/test/Veritas.Tests/Tax/RS/JmbgTests.cs
@@ -29,7 +29,7 @@ public class JmbgTests
     [InlineData("abcdefghijklm")]
     public void ValidateBad(string input)
     {
-        Jmbg.TryValidate(input, out var r).ShouldBeTrue();
+        Jmbg.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/SE/OrgNrTests.cs
+++ b/test/Veritas.Tests/Tax/SE/OrgNrTests.cs
@@ -9,7 +9,7 @@ public class OrgNrTests
     [InlineData("5560160681", false)]
     public void Validate(string input, bool expected)
     {
-        OrgNr.TryValidate(input, out var result);
+        OrgNr.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/SE/PersonnummerTests.cs
+++ b/test/Veritas.Tests/Tax/SE/PersonnummerTests.cs
@@ -9,7 +9,7 @@ public class PersonnummerTests
     [InlineData("8507099804", false)]
     public void Validate(string input, bool expected)
     {
-        Personnummer.TryValidate(input, out var result);
+        Personnummer.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/SG/UenTests.cs
+++ b/test/Veritas.Tests/Tax/SG/UenTests.cs
@@ -10,7 +10,7 @@ public class UenTests
     {
         Span<char> buffer = stackalloc char[10];
         Uen.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Uen.TryValidate(buffer[..written], out var result);
+        Uen.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 
@@ -20,7 +20,7 @@ public class UenTests
         Span<char> buffer = stackalloc char[10];
         Uen.TryGenerate(new GenerationOptions { Seed = 4 }, buffer, out var w).ShouldBeTrue();
         buffer[w - 1] = buffer[w - 1] == '0' ? '1' : '0';
-        Uen.TryValidate(buffer[..w], out var result);
+        Uen.TryValidate(buffer[..w], out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/SI/EmsoTests.cs
+++ b/test/Veritas.Tests/Tax/SI/EmsoTests.cs
@@ -29,7 +29,7 @@ public class EmsoTests
     [InlineData("abcdefghijklm")]
     public void ValidateBad(string input)
     {
-        Emso.TryValidate(input, out var r).ShouldBeTrue();
+        Emso.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/SK/RodneCisloTests.cs
+++ b/test/Veritas.Tests/Tax/SK/RodneCisloTests.cs
@@ -9,7 +9,7 @@ public class SkRodneCisloTests
     [InlineData("850712/1239", false)]
     public void Validate_Works(string input, bool expected)
     {
-        RodneCislo.TryValidate(input, out var result);
+        RodneCislo.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class SkRodneCisloTests
     {
         Span<char> buffer = stackalloc char[10];
         RodneCislo.TryGenerate(buffer, out var written).ShouldBeTrue();
-        RodneCislo.TryValidate(buffer[..written], out var result);
+        RodneCislo.TryValidate(buffer[..written], out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/TR/TcknTests.cs
+++ b/test/Veritas.Tests/Tax/TR/TcknTests.cs
@@ -29,7 +29,7 @@ public class TcknTests
     [InlineData("abcdefghijk")]
     public void ValidateBad(string input)
     {
-        Tckn.TryValidate(input, out var r).ShouldBeTrue();
+        Tckn.TryValidate(input, out var r).ShouldBeFalse();
         r.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/UK/CompanyNumberTests.cs
+++ b/test/Veritas.Tests/Tax/UK/CompanyNumberTests.cs
@@ -11,14 +11,14 @@ public class CompanyNumberTests
     [InlineData("1234567", false)]
     public void Validate(string input, bool expected)
     {
-        CompanyNumber.TryValidate(input, out var result);
+        CompanyNumber.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
     [Theory, AutoData]
     public void RandomString_IsInvalid(string random)
     {
-        CompanyNumber.TryValidate(random, out var result);
+        CompanyNumber.TryValidate(random, out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/UK/NinoTests.cs
+++ b/test/Veritas.Tests/Tax/UK/NinoTests.cs
@@ -9,7 +9,7 @@ public class NinoTests
     [InlineData("DQ123456A", false)]
     public void Validate(string input, bool expected)
     {
-        Nino.TryValidate(input, out var r);
+        Nino.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/UK/UtrTests.cs
+++ b/test/Veritas.Tests/Tax/UK/UtrTests.cs
@@ -14,7 +14,7 @@ public class UtrTests
     [InlineData("11234A6789", false)]
     public void Validate(string input, bool expected)
     {
-        Utr.TryValidate(input, out var r);
+        Utr.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -23,7 +23,7 @@ public class UtrTests
     {
         Span<char> buffer = stackalloc char[10];
         Utr.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Utr.TryValidate(buffer[..written], out var r);
+        Utr.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Tax/UK/VatTests.cs
+++ b/test/Veritas.Tests/Tax/UK/VatTests.cs
@@ -11,14 +11,14 @@ public class UkVatTests
     [InlineData("980780685", false)]
     public void Validate(string input, bool expected)
     {
-        Vat.TryValidate(input, out var result);
+        Vat.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 
     [Theory, AutoData]
     public void RandomString_IsInvalid(string random)
     {
-        Vat.TryValidate(random, out var result);
+        Vat.TryValidate(random, out var result).ShouldBeFalse();
         result.IsValid.ShouldBeFalse();
     }
 }

--- a/test/Veritas.Tests/Tax/US/EinTests.cs
+++ b/test/Veritas.Tests/Tax/US/EinTests.cs
@@ -9,7 +9,7 @@ public class EinTests
     [InlineData("00-1234567", false)]
     public void Validate(string input, bool expected)
     {
-        Ein.TryValidate(input, out var r);
+        Ein.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/US/ItinTests.cs
+++ b/test/Veritas.Tests/Tax/US/ItinTests.cs
@@ -9,7 +9,7 @@ public class ItinTests
     [InlineData("912-93-4567", false)]
     public void Validate(string input, bool expected)
     {
-        Itin.TryValidate(input, out var r);
+        Itin.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Tax/US/SsnTests.cs
+++ b/test/Veritas.Tests/Tax/US/SsnTests.cs
@@ -9,7 +9,7 @@ public class SsnTests
     [InlineData("000-00-0000", false)]
     public void Validate(string input, bool expected)
     {
-        Ssn.TryValidate(input, out var r);
+        Ssn.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class SsnTests
     {
         Span<char> buffer = stackalloc char[9];
         Ssn.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Ssn.TryValidate(buffer[..written], out var r);
+        Ssn.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Telecom/AsnTests.cs
+++ b/test/Veritas.Tests/Telecom/AsnTests.cs
@@ -12,7 +12,7 @@ public class AsnTests
     [InlineData("abc", false)]
     public void Validate(string input, bool expected)
     {
-        Asn.TryValidate(input, out var result);
+        Asn.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Telecom/IccidTests.cs
+++ b/test/Veritas.Tests/Telecom/IccidTests.cs
@@ -10,7 +10,7 @@ public class IccidTests
     [InlineData("8914800000000000001", false)]
     public void Validate(string input, bool expected)
     {
-        Iccid.TryValidate(input, out var r);
+        Iccid.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class IccidTests
     {
         Span<char> buffer = stackalloc char[20];
         Iccid.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Iccid.TryValidate(buffer[..written], out var r);
+        Iccid.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Telecom/ImeiTests.cs
+++ b/test/Veritas.Tests/Telecom/ImeiTests.cs
@@ -10,7 +10,7 @@ public class ImeiTests
     [InlineData("490154203237519", false)]
     public void Validate(string input, bool expected)
     {
-        Imei.TryValidate(input, out var r);
+        Imei.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -19,7 +19,7 @@ public class ImeiTests
     {
         Span<char> buffer = stackalloc char[15];
         Imei.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Imei.TryValidate(buffer[..written], out var r);
+        Imei.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Telecom/Ipv4Tests.cs
+++ b/test/Veritas.Tests/Telecom/Ipv4Tests.cs
@@ -9,7 +9,7 @@ public class Ipv4Tests
     [InlineData("256.0.0.1", false)]
     public void Validate(string input, bool expected)
     {
-        Ipv4.TryValidate(input, out var r);
+        Ipv4.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Telecom/Ipv6Tests.cs
+++ b/test/Veritas.Tests/Telecom/Ipv6Tests.cs
@@ -9,7 +9,7 @@ public class Ipv6Tests
     [InlineData("2001::85a3::7334", false)]
     public void Validate(string input, bool expected)
     {
-        Ipv6.TryValidate(input, out var r);
+        Ipv6.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Telecom/MacTests.cs
+++ b/test/Veritas.Tests/Telecom/MacTests.cs
@@ -9,7 +9,7 @@ public class MacTests
     [InlineData("00:1A:2B:3C:4D:5G", false)]
     public void Validate(string input, bool expected)
     {
-        Mac.TryValidate(input, out var r);
+        Mac.TryValidate(input, out var r).ShouldBe(expected);
         r.IsValid.ShouldBe(expected);
     }
 
@@ -18,7 +18,7 @@ public class MacTests
     {
         Span<char> buffer = stackalloc char[12];
         Mac.TryGenerate(buffer, out var written).ShouldBeTrue();
-        Mac.TryValidate(buffer[..written], out var r);
+        Mac.TryValidate(buffer[..written], out var r).ShouldBeTrue();
         r.IsValid.ShouldBeTrue();
     }
 }

--- a/test/Veritas.Tests/Telecom/MeidTests.cs
+++ b/test/Veritas.Tests/Telecom/MeidTests.cs
@@ -10,7 +10,7 @@ public class MeidTests
     [InlineData("A000000000232", false)]
     public void Validate(string input, bool expected)
     {
-        Meid.TryValidate(input, out var result);
+        Meid.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }

--- a/test/Veritas.Tests/Telecom/OuiTests.cs
+++ b/test/Veritas.Tests/Telecom/OuiTests.cs
@@ -11,7 +11,7 @@ public class OuiTests
     [InlineData("00A0CZ", false)]
     public void Validate(string input, bool expected)
     {
-        Oui.TryValidate(input, out var result);
+        Oui.TryValidate(input, out var result).ShouldBe(expected);
         result.IsValid.ShouldBe(expected);
     }
 }


### PR DESCRIPTION
## Summary
- Align TryValidate implementations with .NET conventions so the boolean return reflects validation success
- Update README and docfx examples to demonstrate new semantics
- Revise tests and validator implementations to match the new behavior

## Testing
- `dotnet format Veritas.sln --no-restore -v diagnostic`
- `dotnet test --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68c541e0f5f4832bb1382204e2e3109a