### PR TITLE
feat: expand checksum algorithm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,23 @@ dotnet add package Veritas --version 1.0.3
 ## Currently implemented
 
 ### Algorithms
-- Luhn (mod 10)
-- ISO 7064 (mod 11,10; mod 97; mod 37,2)
+- Luhn (mod 10 and base-36)
+- ISO 7064 (mod 11,10; mod 97; mod 37,2; mod 37,36)
 - GS1 mod 10
-- Weighted mod 11 variants
+- Weighted mod 11 variants (custom weights)
 - ISO 6346 container check digit
 - MRZ (ICAO 9303 7-3-1 pattern)
 - Base58Check codec
 - Verhoeff checksum
 - Damm checksum
+- Checksum strategies via `IChecksum` interface and transliteration helpers
 
 ### Finance
 - IBAN validation (ISO 13616 / ISO 7064 mod 97)
 - BIC/SWIFT code structural validation
 - ISIN validation (alphabetic + numeric with Luhn check digit)
 - ISO 11649 RF creditor reference validation and generation
+- Belgium structured communication (OGM) validation and generation
 - Payment card PAN validation (Luhn)
 - US ABA routing number validation
 - Mexican CLABE validation and generation
@@ -68,6 +70,7 @@ dotnet add package Veritas --version 1.0.3
 - Base58Check validation and generation
 - India Aadhaar validation and generation
 - Luxembourg National ID validation and generation
+- France NIR (INSEE) validation and generation
 
 ### Tax
 - Brazil CPF validation/generation
@@ -107,6 +110,7 @@ dotnet add package Veritas --version 1.0.3
 - Belgium National Number validation/generation
 - Portugal NIF validation/generation
 - Greece AFM validation/generation
+- Hungary VAT (Adószám) validation/generation
 - Finland HETU validation/generation
 - Ireland PPSN validation/generation
 - Norway Fodselsnummer validation/generation
@@ -118,6 +122,8 @@ dotnet add package Veritas --version 1.0.3
 - Bulgaria EGN validation/generation
 - Slovenia EMSO validation/generation
 - Serbia JMBG validation/generation
+- Bosnia and Herzegovina JMBG validation/generation
+- North Macedonia EMBG validation/generation
 - Switzerland AHV validation/generation
 - Switzerland UID validation/generation
 - Austria UID validation/generation
@@ -140,6 +146,9 @@ dotnet add package Veritas --version 1.0.3
 - GTIN/EAN/UPC validation and generation (GS1 mod 10)
 - Global Location Number (GLN) validation and generation
 - Serial Shipping Container Code (SSCC) validation and generation
+- Global Service Relation Number (GSRN) validation and generation
+- Global Returnable Asset Identifier (GRAI) validation and generation
+- Global Shipment Identification Number (GSIN) validation and generation
 - Vehicle Identification Number (VIN) validation
 - ISO 6346 container code validation
 - Air Waybill (AWB) validation and generation

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -41,6 +41,19 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 }
 ```
 
+## Algorithms
+
+- Luhn (mod 10 and base-36)
+- ISO 7064 (mod 11,10; mod 97; mod 37,2; mod 37,36)
+- GS1 mod 10
+- Weighted mod 11 variants (custom weights)
+- ISO 6346 container check digit
+- MRZ (ICAO 9303 7-3-1 pattern)
+- Base58Check codec
+- Verhoeff checksum
+- Damm checksum
+- Checksum strategies via `IChecksum` interface and transliteration helpers
+
 ## Supported identifiers
 
 ### Finance
@@ -51,6 +64,7 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | BIC/SWIFT | International | format check | <xref:Veritas.Finance.Bic> |
 | ISIN | International | Luhn checksum | <xref:Veritas.Finance.Isin> |
 | RF Creditor Reference | International | ISO 11649 mod 97; generation | <xref:Veritas.Finance.Rf> |
+| Structured Reference (OGM) | BE | mod 97 checksum; generation | <xref:Veritas.Finance.BE.Ogm> |
 | Payment card PAN | International | Luhn checksum; test generation | <xref:Veritas.Finance.Pan> |
 | ABA Routing | US | weighted mod 11 checksum | <xref:Veritas.Finance.AbaRouting> |
 | CLABE | Mexico | weighted mod 11 checksum; generation | <xref:Veritas.Finance.Clabe> |
@@ -95,6 +109,7 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | CURP | Mexico | mod 10 checksum; generation | <xref:Veritas.Identity.Mexico.Curp> |
 | National ID | South Africa | Luhn checksum; generation | <xref:Veritas.Identity.SouthAfrica.NationalId> |
 | Teudat Zehut | Israel | weighted mod 10 checksum; generation | <xref:Veritas.Identity.Israel.TeudatZehut> |
+| NIR (INSEE) | France | mod 97 key; generation | <xref:Veritas.Identity.France.Nir> |
 
 ### Tax
 
@@ -121,11 +136,14 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | FR | Siret | mod 11 checksum | <xref:Veritas.Tax.FR.Siret> |
 | FR | VAT | ISO 7064 mod 97 checksum | <xref:Veritas.Tax.FR.Vat> |
 | GR | AFM | mod 11 checksum; generation | <xref:Veritas.Tax.GR.Afm> |
+| HU | Adoszam | weighted mod 10 checksum; generation | <xref:Veritas.Tax.HU.Adoszam> |
 | HR | OIB | ISO 7064 mod 11,10 checksum; generation | <xref:Veritas.Tax.HR.Oib> |
 | RO | CNP | mod 11 checksum; generation | <xref:Veritas.Tax.RO.Cnp> |
 | BG | EGN | weighted checksum; generation | <xref:Veritas.Tax.BG.Egn> |
 | SI | EMSO | mod 11 checksum; generation | <xref:Veritas.Tax.SI.Emso> |
 | RS | JMBG | mod 11 checksum; generation | <xref:Veritas.Tax.RS.Jmbg> |
+| BA | JMBG | mod 11 checksum; generation | <xref:Veritas.Tax.BA.Jmbg> |
+| MK | EMBG | mod 11 checksum; generation | <xref:Veritas.Tax.MK.Embg> |
 | CH | AHV | ISO 7064 mod 11,10 checksum; generation | <xref:Veritas.Tax.CH.Ahv> |
 | CH | UID | mod 10 (EAN) checksum; generation | <xref:Veritas.Tax.CH.Uid> |
 | AT | UID | weighted mod 10 checksum; generation | <xref:Veritas.Tax.AT.Uid> |
@@ -171,6 +189,9 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | GTIN/EAN/UPC | International | GS1 mod 10 checksum; generation | <xref:Veritas.Logistics.Gtin> |
 | GLN | International | GS1 mod 10 checksum; generation | <xref:Veritas.Logistics.Gln> |
 | SSCC | International | GS1 mod 10 checksum; generation | <xref:Veritas.Logistics.Sscc> |
+| GSRN | International | GS1 mod 10 checksum; generation | <xref:Veritas.Logistics.Gsrn> |
+| GRAI | International | GS1 mod 10 checksum; generation | <xref:Veritas.Logistics.Grai> |
+| GSIN | International | GS1 mod 10 checksum; generation | <xref:Veritas.Logistics.Gsin> |
 | VIN | International | transliteration + weighted checksum | <xref:Veritas.Logistics.Vin> |
 | ISO 6346 | International | ISO 6346 checksum | <xref:Veritas.Logistics.Iso6346> |
 | AWB | International | mod 7 checksum; generation | <xref:Veritas.Logistics.Awb> |

--- a/src/Veritas/Core/Algorithms/ChecksumStrategies.cs
+++ b/src/Veritas/Core/Algorithms/ChecksumStrategies.cs
@@ -1,0 +1,90 @@
+using System;
+using LuhnAlgo = global::Veritas.Algorithms.Luhn;
+using Mod11Algo = global::Veritas.Algorithms.Mod11;
+using Iso7064Algo = global::Veritas.Algorithms.Iso7064;
+
+namespace Veritas.Algorithms;
+
+/// <summary>Provides reusable checksum strategies.</summary>
+public static class ChecksumStrategies
+{
+    /// <summary>Gets an <see cref="IChecksum"/> for the numeric Luhn (mod 10) algorithm.</summary>
+    public static IChecksum Luhn { get; } = new LuhnStrategy();
+
+    /// <summary>Gets an <see cref="IChecksum"/> for the alphanumeric Luhn (base-36) algorithm.</summary>
+    public static IChecksum LuhnBase36 { get; } = new LuhnBase36Strategy();
+
+    /// <summary>Gets an <see cref="IChecksum"/> for GS1 mod 10 (weight pattern 3/1).</summary>
+    public static IChecksum Gs1Mod10 { get; } = new Gs1Mod10Strategy();
+
+    /// <summary>Creates a weighted mod 11 checksum strategy.</summary>
+    public static IChecksum CreateWeightedMod11(ReadOnlySpan<int> weights, bool fromRight = false)
+        => new WeightedMod11Strategy(weights.ToArray(), fromRight);
+
+    /// <summary>Gets an <see cref="IChecksum"/> for ISO 7064 Mod 37,36.</summary>
+    public static IChecksum Iso7064Mod37_36 { get; } = new Iso7064Mod37_36Strategy();
+
+    private sealed class LuhnStrategy : IChecksum
+    {
+        public string Compute(ReadOnlySpan<char> input)
+            => LuhnAlgo.ComputeCheckDigit(input).ToString();
+
+        public bool Verify(ReadOnlySpan<char> input, ReadOnlySpan<char> expected)
+            => expected.Length == 1 && LuhnAlgo.ComputeCheckDigit(input) == expected[0] - '0';
+    }
+
+    private sealed class LuhnBase36Strategy : IChecksum
+    {
+        public string Compute(ReadOnlySpan<char> input)
+            => LuhnAlgo.ComputeCheckCharacterBase36(input).ToString();
+
+        public bool Verify(ReadOnlySpan<char> input, ReadOnlySpan<char> expected)
+            => expected.Length == 1 && char.ToUpperInvariant(LuhnAlgo.ComputeCheckCharacterBase36(input)) == char.ToUpperInvariant(expected[0]);
+    }
+
+    private sealed class Gs1Mod10Strategy : IChecksum
+    {
+        public string Compute(ReadOnlySpan<char> input)
+        {
+            int sum = 0;
+            bool three = true;
+            for (int i = input.Length - 1; i >= 0; i--)
+            {
+                int d = input[i] - '0';
+                if ((uint)d > 9) throw new ArgumentException("Non-digit character present", nameof(input));
+                sum += d * (three ? 3 : 1);
+                three = !three;
+            }
+            int check = (10 - (sum % 10)) % 10;
+            return ((char)('0' + check)).ToString();
+        }
+
+        public bool Verify(ReadOnlySpan<char> input, ReadOnlySpan<char> expected)
+            => expected.Length == 1 && Compute(input)[0] == expected[0];
+    }
+
+    private sealed class WeightedMod11Strategy : IChecksum
+    {
+        private readonly int[] _weights;
+        private readonly bool _fromRight;
+        public WeightedMod11Strategy(int[] weights, bool fromRight)
+        {
+            _weights = weights;
+            _fromRight = fromRight;
+        }
+        public string Compute(ReadOnlySpan<char> input)
+            => Mod11Algo.ComputeCheckCharacter(input, _weights, _fromRight).ToString();
+
+        public bool Verify(ReadOnlySpan<char> input, ReadOnlySpan<char> expected)
+            => expected.Length == 1 && Mod11Algo.ComputeCheckCharacter(input, _weights, _fromRight) == expected[0];
+    }
+
+    private sealed class Iso7064Mod37_36Strategy : IChecksum
+    {
+        public string Compute(ReadOnlySpan<char> input)
+            => Iso7064Algo.ComputeCheckCharacterMod37_36(input).ToString();
+
+        public bool Verify(ReadOnlySpan<char> input, ReadOnlySpan<char> expected)
+            => expected.Length == 1 && char.ToUpperInvariant(Iso7064Algo.ComputeCheckCharacterMod37_36(input)) == char.ToUpperInvariant(expected[0]);
+    }
+}

--- a/src/Veritas/Core/Algorithms/IChecksum.cs
+++ b/src/Veritas/Core/Algorithms/IChecksum.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Veritas.Algorithms;
+
+/// <summary>Defines a checksum strategy with compute and verify operations.</summary>
+public interface IChecksum
+{
+    /// <summary>Computes the check character(s) for the provided input.</summary>
+    /// <param name="input">Input string without the check character(s).</param>
+    /// <returns>Computed check character(s) as a string.</returns>
+    string Compute(ReadOnlySpan<char> input);
+
+    /// <summary>Verifies that the provided input matches the expected check character(s).</summary>
+    /// <param name="input">Input string without the check character(s).</param>
+    /// <param name="expected">Expected check character(s).</param>
+    /// <returns><c>true</c> if the checksum matches; otherwise <c>false</c>.</returns>
+    bool Verify(ReadOnlySpan<char> input, ReadOnlySpan<char> expected);
+
+    /// <summary>Convenience method to compute a single check digit.</summary>
+    /// <param name="input">Input string without the check digit.</param>
+    /// <returns>The computed check digit.</returns>
+    char ComputeCheckDigit(ReadOnlySpan<char> input) => Compute(input)[0];
+}

--- a/src/Veritas/Core/Algorithms/Luhn.cs
+++ b/src/Veritas/Core/Algorithms/Luhn.cs
@@ -1,7 +1,7 @@
 using System;
 namespace Veritas.Algorithms;
 
-/// <summary>Provides the Luhn (mod 10) checksum algorithm.</summary>
+/// <summary>Provides the Luhn checksum algorithm, including the standard mod 10 and generalized base-36 variants.</summary>
 internal static class Luhn
 {
     /// <summary>Computes the Luhn check digit for the provided numeric string (without the check digit).</summary>
@@ -43,5 +43,66 @@ internal static class Luhn
             doubleDigit = !doubleDigit;
         }
         return sum % 10 == 0;
+    }
+
+    private static bool TryGetBase36Value(char ch, out int value)
+    {
+        if (ch >= '0' && ch <= '9') { value = ch - '0'; return true; }
+        if (ch >= 'A' && ch <= 'Z') { value = ch - 'A' + 10; return true; }
+        if (ch >= 'a' && ch <= 'z') { value = ch - 'a' + 10; return true; }
+        value = 0;
+        return false;
+    }
+
+    private static int CharToBase36(char ch)
+    {
+        if (TryGetBase36Value(ch, out int value)) return value;
+        throw new ArgumentException("Non-alphanumeric character present", nameof(ch));
+    }
+
+    private static char ValueToBase36(int value)
+        => value < 10 ? (char)('0' + value) : (char)('A' + value - 10);
+
+    /// <summary>Computes the generalized Luhn (base-36) check character for the provided string.</summary>
+    public static char ComputeCheckCharacterBase36(ReadOnlySpan<char> input)
+    {
+        int sum = 0;
+        bool doubleDigit = true;
+        for (int i = input.Length - 1; i >= 0; i--)
+        {
+            int d = CharToBase36(input[i]);
+            if (doubleDigit)
+            {
+                d *= 2;
+                if (d >= 36) d -= 35;
+            }
+            sum += d;
+            doubleDigit = !doubleDigit;
+        }
+        int check = (36 - (sum % 36)) % 36;
+        return ValueToBase36(check);
+    }
+
+    /// <summary>Validates that the supplied string satisfies the generalized Luhn (base-36) checksum.</summary>
+    public static bool ValidateBase36(ReadOnlySpan<char> input)
+    {
+        if (input.IsEmpty) return false;
+        int sum = 0;
+        bool doubleDigit = false;
+        for (int i = input.Length - 1; i >= 0; i--)
+        {
+            if (!TryGetBase36Value(input[i], out int d))
+            {
+                return false;
+            }
+            if (doubleDigit)
+            {
+                d *= 2;
+                if (d >= 36) d -= 35;
+            }
+            sum += d;
+            doubleDigit = !doubleDigit;
+        }
+        return sum % 36 == 0;
     }
 }

--- a/src/Veritas/Core/Algorithms/Mod11.cs
+++ b/src/Veritas/Core/Algorithms/Mod11.cs
@@ -4,15 +4,77 @@ namespace Veritas.Algorithms;
 
 internal static class Mod11
 {
-    public static int WeightedSum(ReadOnlySpan<char> digits, ReadOnlySpan<int> weights)
+    /// <summary>Computes a weighted sum of the supplied numeric digits.</summary>
+    /// <param name="digits">Numeric digits to weight.</param>
+    /// <param name="weights">Weight pattern to apply. When shorter than <paramref name="digits"/> it repeats.</param>
+    /// <param name="fromRight">Whether to apply weights starting from the right-most digit.</param>
+    public static int WeightedSum(ReadOnlySpan<char> digits, ReadOnlySpan<int> weights, bool fromRight = false)
     {
+        if (weights.IsEmpty) throw new ArgumentException("Weights cannot be empty", nameof(weights));
+
         int sum = 0;
-        for (int i = 0; i < weights.Length; i++)
-            sum += (digits[i] - '0') * weights[i];
+        if (fromRight)
+        {
+            int wi = 0;
+            for (int i = digits.Length - 1; i >= 0; i--)
+            {
+                int d = digits[i] - '0';
+                if ((uint)d > 9) throw new ArgumentException("Non-digit character present", nameof(digits));
+                sum += d * weights[wi];
+                wi++;
+                if (wi == weights.Length) wi = 0;
+            }
+        }
+        else
+        {
+            int wi = 0;
+            for (int i = 0; i < digits.Length; i++)
+            {
+                int d = digits[i] - '0';
+                if ((uint)d > 9) throw new ArgumentException("Non-digit character present", nameof(digits));
+                sum += d * weights[wi];
+                wi++;
+                if (wi == weights.Length) wi = 0;
+            }
+        }
         return sum;
     }
 
-    public static int ComputeMod11(ReadOnlySpan<char> digits, ReadOnlySpan<int> weights)
-        => WeightedSum(digits, weights) % 11;
+    /// <summary>Computes the mod 11 remainder for the weighted digits.</summary>
+    public static int ComputeMod11(ReadOnlySpan<char> digits, ReadOnlySpan<int> weights, bool fromRight = false)
+        => WeightedSum(digits, weights, fromRight) % 11;
+
+    /// <summary>Computes the mod 11 check digit value for the supplied digits.</summary>
+    public static int ComputeCheckDigit(ReadOnlySpan<char> digits, ReadOnlySpan<int> weights, bool fromRight = false)
+    {
+        int rem = ComputeMod11(digits, weights, fromRight);
+        return (11 - rem) % 11;
+    }
+
+    /// <summary>Computes the mod 11 check character for the supplied digits, using 'X' to represent a value of 10.</summary>
+    public static char ComputeCheckCharacter(ReadOnlySpan<char> digits, ReadOnlySpan<int> weights, bool fromRight = false)
+    {
+        int check = ComputeCheckDigit(digits, weights, fromRight);
+        return check == 10 ? 'X' : (char)('0' + check);
+    }
+
+    /// <summary>Validates that the supplied string satisfies the weighted mod 11 checksum.</summary>
+    public static bool Validate(ReadOnlySpan<char> input, ReadOnlySpan<int> weights, bool fromRight = false)
+    {
+        if (input.Length < 2) return false;
+        int check;
+        try
+        {
+            check = ComputeCheckDigit(input[..^1], weights, fromRight);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        char checkChar = input[^1];
+        if (check == 10)
+            return checkChar == 'X' || checkChar == 'x';
+        return checkChar == (char)('0' + check);
+    }
 }
 

--- a/src/Veritas/Core/Transliteration.cs
+++ b/src/Veritas/Core/Transliteration.cs
@@ -1,0 +1,58 @@
+using System;
+
+namespace Veritas;
+
+/// <summary>Provides transliteration helpers for various identifier schemes.</summary>
+public static class Transliteration
+{
+    /// <summary>Attempts to transliterate a VIN character to its numeric value.</summary>
+    public static bool TryVin(char ch, out int value)
+    {
+        if (ch >= '0' && ch <= '9') { value = ch - '0'; return true; }
+        if (ch >= 'A' && ch <= 'Z')
+        {
+            value = ch switch
+            {
+                'A' => 1,
+                'B' => 2,
+                'C' => 3,
+                'D' => 4,
+                'E' => 5,
+                'F' => 6,
+                'G' => 7,
+                'H' => 8,
+                'J' => 1,
+                'K' => 2,
+                'L' => 3,
+                'M' => 4,
+                'N' => 5,
+                'P' => 7,
+                'R' => 9,
+                'S' => 2,
+                'T' => 3,
+                'U' => 4,
+                'V' => 5,
+                'W' => 6,
+                'X' => 7,
+                'Y' => 8,
+                'Z' => 9,
+                _ => 0
+            };
+            return value != 0;
+        }
+        if (ch >= 'a' && ch <= 'z')
+            return TryVin(char.ToUpperInvariant(ch), out value);
+        value = 0;
+        return false;
+    }
+
+    /// <summary>Attempts to transliterate an alphanumeric base-36 character.</summary>
+    public static bool TryBase36(char ch, out int value)
+    {
+        if (ch >= '0' && ch <= '9') { value = ch - '0'; return true; }
+        if (ch >= 'A' && ch <= 'Z') { value = ch - 'A' + 10; return true; }
+        if (ch >= 'a' && ch <= 'z') { value = ch - 'a' + 10; return true; }
+        value = 0;
+        return false;
+    }
+}

--- a/src/Veritas/Finance/BE/Ogm.cs
+++ b/src/Veritas/Finance/BE/Ogm.cs
@@ -1,0 +1,77 @@
+using System;
+using Veritas;
+
+namespace Veritas.Finance.BE;
+
+/// <summary>Belgian structured communication (OGM) reference.</summary>
+public static class Ogm
+{
+    /// <summary>Attempts to validate a structured communication reference.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<OgmValue> result)
+    {
+        Span<char> digits = stackalloc char[12];
+        if (!Normalize(input, digits, out int len) || len != 12)
+        {
+            result = new ValidationResult<OgmValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        long baseNumber = ParseLong(digits[..10]);
+        int expected = (int)(baseNumber % 97);
+        if (expected == 0) expected = 97;
+        int check = (digits[10] - '0') * 10 + (digits[11] - '0');
+        if (check != expected)
+        {
+            result = new ValidationResult<OgmValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<OgmValue>(true, new OgmValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a structured communication reference.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a structured communication reference.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        written = 0;
+        if (destination.Length < 12) return false;
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        Span<char> digits = destination[..12];
+        for (int i = 0; i < 10; i++)
+            digits[i] = (char)('0' + rng.Next(10));
+        long baseNumber = ParseLong(digits[..10]);
+        int check = (int)(baseNumber % 97);
+        if (check == 0) check = 97;
+        digits[10] = (char)('0' + check / 10);
+        digits[11] = (char)('0' + check % 10);
+        written = 12;
+        return true;
+    }
+
+    private static long ParseLong(ReadOnlySpan<char> digits)
+    {
+        long n = 0;
+        foreach (var ch in digits)
+            n = n * 10 + (ch - '0');
+        return n;
+    }
+
+    private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
+    {
+        len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '/' || ch == '-' || ch == '+')
+                continue;
+            if (!char.IsDigit(ch) || len >= dest.Length)
+            {
+                len = 0;
+                return false;
+            }
+            dest[len++] = ch;
+        }
+        return true;
+    }
+}

--- a/src/Veritas/Finance/BE/OgmValue.cs
+++ b/src/Veritas/Finance/BE/OgmValue.cs
@@ -1,0 +1,13 @@
+namespace Veritas.Finance.BE;
+
+/// <summary>Represents a validated Belgian structured communication reference.</summary>
+public readonly struct OgmValue
+{
+    /// <summary>Gets the normalized reference string.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new <see cref="OgmValue"/>.</summary>
+    public OgmValue(string value) => Value = value;
+
+    public override string ToString() => Value;
+}

--- a/src/Veritas/Identity/France/Nir.cs
+++ b/src/Veritas/Identity/France/Nir.cs
@@ -1,0 +1,98 @@
+using System;
+using Veritas;
+
+namespace Veritas.Identity.France;
+
+/// <summary>Provides validation and generation for French NIR (INSEE) numbers.</summary>
+public static class Nir
+{
+    /// <summary>Attempts to validate the supplied input as a NIR number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<NirValue> result)
+    {
+        Span<char> digits = stackalloc char[15];
+        if (!Normalize(input, digits, out int len) || len != 15)
+        {
+            result = new ValidationResult<NirValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        int mod = 0;
+        for (int i = 0; i < 13; i++)
+        {
+            char ch = digits[i];
+            int d;
+            if (ch == 'A') d = 0;
+            else if (ch == 'B') d = 1;
+            else { d = ch - '0'; if ((uint)d > 9) { result = new ValidationResult<NirValue>(false, default, ValidationError.Charset); return false; } }
+            mod = (mod * 10 + d) % 97;
+        }
+        int key = 97 - mod;
+        int k1 = digits[13] - '0';
+        int k2 = digits[14] - '0';
+        if ((uint)k1 > 9 || (uint)k2 > 9)
+        {
+            result = new ValidationResult<NirValue>(false, default, ValidationError.Charset);
+            return false;
+        }
+        int expected = k1 * 10 + k2;
+        if (expected != key)
+        {
+            result = new ValidationResult<NirValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<NirValue>(true, new NirValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a synthetic NIR number.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a synthetic NIR number.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 15)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 13; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        if (rng.Next(10) == 0)
+            destination[6] = rng.Next(2) == 0 ? 'A' : 'B';
+        int mod = 0;
+        for (int i = 0; i < 13; i++)
+        {
+            char ch = destination[i];
+            int d = ch == 'A' ? 0 : ch == 'B' ? 1 : ch - '0';
+            mod = (mod * 10 + d) % 97;
+        }
+        int key = 97 - mod;
+        destination[13] = (char)('0' + key / 10);
+        destination[14] = (char)('0' + key % 10);
+        written = 15;
+        return true;
+    }
+
+    private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
+    {
+        len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-' || ch == '.')
+                continue;
+            char up = char.ToUpperInvariant(ch);
+            if ((uint)(up - '0') <= 9 || up == 'A' || up == 'B')
+            {
+                if (len >= dest.Length) { len = 0; return false; }
+                dest[len++] = up;
+            }
+            else
+            {
+                len = 0;
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/Veritas/Identity/France/NirValue.cs
+++ b/src/Veritas/Identity/France/NirValue.cs
@@ -1,0 +1,13 @@
+namespace Veritas.Identity.France;
+
+/// <summary>Represents a validated French NIR (INSEE) number.</summary>
+public readonly struct NirValue
+{
+    /// <summary>Gets the normalized NIR string.</summary>
+    public string Value { get; }
+
+    /// <summary>Creates a new <see cref="NirValue"/>.</summary>
+    public NirValue(string value) => Value = value;
+
+    public override string ToString() => Value;
+}

--- a/src/Veritas/Logistics/Grai.cs
+++ b/src/Veritas/Logistics/Grai.cs
@@ -1,0 +1,45 @@
+using System;
+using Veritas.Algorithms;
+using Veritas;
+
+namespace Veritas.Logistics;
+
+public readonly struct GraiValue { public string Value { get; } public GraiValue(string v) => Value = v; }
+
+public static class Grai
+{
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<GraiValue> result)
+    {
+        Span<char> digits = stackalloc char[14];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (ch < '0' || ch > '9') { result = new ValidationResult<GraiValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 14) { result = new ValidationResult<GraiValue>(false, default, ValidationError.Length); return false; }
+            digits[len++] = ch;
+        }
+        if (len != 14) { result = new ValidationResult<GraiValue>(false, default, ValidationError.Length); return false; }
+        if (!Gs1.Validate(digits)) { result = new ValidationResult<GraiValue>(false, default, ValidationError.Checksum); return false; }
+        result = new ValidationResult<GraiValue>(true, new GraiValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 14)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 13; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        destination[13] = (char)('0' + Gs1.ComputeCheckDigit(destination[..13]));
+        written = 14;
+        return true;
+    }
+}

--- a/src/Veritas/Logistics/Gsin.cs
+++ b/src/Veritas/Logistics/Gsin.cs
@@ -1,0 +1,45 @@
+using System;
+using Veritas.Algorithms;
+using Veritas;
+
+namespace Veritas.Logistics;
+
+public readonly struct GsinValue { public string Value { get; } public GsinValue(string v) => Value = v; }
+
+public static class Gsin
+{
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<GsinValue> result)
+    {
+        Span<char> digits = stackalloc char[17];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (ch < '0' || ch > '9') { result = new ValidationResult<GsinValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 17) { result = new ValidationResult<GsinValue>(false, default, ValidationError.Length); return false; }
+            digits[len++] = ch;
+        }
+        if (len != 17) { result = new ValidationResult<GsinValue>(false, default, ValidationError.Length); return false; }
+        if (!Gs1.Validate(digits)) { result = new ValidationResult<GsinValue>(false, default, ValidationError.Checksum); return false; }
+        result = new ValidationResult<GsinValue>(true, new GsinValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 17)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 16; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        destination[16] = (char)('0' + Gs1.ComputeCheckDigit(destination[..16]));
+        written = 17;
+        return true;
+    }
+}

--- a/src/Veritas/Logistics/Gsrn.cs
+++ b/src/Veritas/Logistics/Gsrn.cs
@@ -1,0 +1,45 @@
+using System;
+using Veritas.Algorithms;
+using Veritas;
+
+namespace Veritas.Logistics;
+
+public readonly struct GsrnValue { public string Value { get; } public GsrnValue(string v) => Value = v; }
+
+public static class Gsrn
+{
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<GsrnValue> result)
+    {
+        Span<char> digits = stackalloc char[18];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (ch < '0' || ch > '9') { result = new ValidationResult<GsrnValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 18) { result = new ValidationResult<GsrnValue>(false, default, ValidationError.Length); return false; }
+            digits[len++] = ch;
+        }
+        if (len != 18) { result = new ValidationResult<GsrnValue>(false, default, ValidationError.Length); return false; }
+        if (!Gs1.Validate(digits)) { result = new ValidationResult<GsrnValue>(false, default, ValidationError.Checksum); return false; }
+        result = new ValidationResult<GsrnValue>(true, new GsrnValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 18)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 17; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        destination[17] = (char)('0' + Gs1.ComputeCheckDigit(destination[..17]));
+        written = 18;
+        return true;
+    }
+}

--- a/src/Veritas/Tax/AU/Tfn.cs
+++ b/src/Veritas/Tax/AU/Tfn.cs
@@ -48,23 +48,20 @@ public static class Tfn
         written = 0;
         if (destination.Length < 9) return false;
         var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
-        int len = 9;
-        Span<char> digits = destination[..len];
-        for (int i = 0; i < len - 1; i++)
-            digits[i] = (char)('0' + rng.Next(10));
-        var weights = Weights9;
-        for (int check = 0; check < 10; check++)
+        Span<char> digits = destination[..9];
+        while (true)
         {
-            digits[len - 1] = (char)('0' + check);
+            for (int i = 0; i < 8; i++)
+                digits[i] = (char)('0' + rng.Next(10));
             int sum = 0;
-            for (int i = 0; i < len; i++) sum += (digits[i] - '0') * weights[i];
-            if (sum % 11 == 0)
-            {
-                written = len;
-                return true;
-            }
+            for (int i = 0; i < 8; i++)
+                sum += (digits[i] - '0') * Weights9[i];
+            int check = ((11 - (sum % 11)) * 10) % 11;
+            if (check == 10) continue;
+            digits[8] = (char)('0' + check);
+            written = 9;
+            return true;
         }
-        return false;
     }
 
     private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)

--- a/src/Veritas/Tax/BA/Jmbg.cs
+++ b/src/Veritas/Tax/BA/Jmbg.cs
@@ -1,0 +1,101 @@
+using System;
+using Veritas;
+
+namespace Veritas.Tax.BA;
+
+/// <summary>Represents a validated Bosnia and Herzegovina JMBG number.</summary>
+public readonly struct JmbgValue
+{
+    /// <summary>Gets the normalized JMBG string.</summary>
+    public string Value { get; }
+
+    /// <summary>Creates a new <see cref="JmbgValue"/>.</summary>
+    public JmbgValue(string value) => Value = value;
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// Bosnia and Herzegovina JMBG personal number (13 digits, mod-11 checksum).
+/// </summary>
+public static class Jmbg
+{
+    private static readonly int[] Weights = { 7, 6, 5, 4, 3, 2, 7, 6, 5, 4, 3, 2 };
+    /// <summary>Attempts to validate the supplied input as a Bosnia and Herzegovina JMBG number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<JmbgValue> result)
+    {
+        Span<char> digits = stackalloc char[13];
+        if (!Normalize(input, digits, out int len))
+        {
+            result = new ValidationResult<JmbgValue>(false, default, ValidationError.Format);
+            return false;
+        }
+        if (len != 13)
+        {
+            result = new ValidationResult<JmbgValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        int check = ComputeCheckDigit(digits[..12]);
+        if (digits[12] - '0' != check)
+        {
+            result = new ValidationResult<JmbgValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<JmbgValue>(true, new JmbgValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a synthetic Bosnia and Herzegovina JMBG number.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a synthetic Bosnia and Herzegovina JMBG number.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        written = 0;
+        if (destination.Length < 13) return false;
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        Span<char> digits = destination[..13];
+        int year = rng.Next(1900, 2100);
+        int month = rng.Next(1, 13);
+        int day = rng.Next(1, DateTime.DaysInMonth(year, month) + 1);
+        digits[0] = (char)('0' + (day / 10));
+        digits[1] = (char)('0' + (day % 10));
+        digits[2] = (char)('0' + (month / 10));
+        digits[3] = (char)('0' + (month % 10));
+        int y = year % 1000;
+        digits[4] = (char)('0' + (y / 100));
+        digits[5] = (char)('0' + (y / 10 % 10));
+        digits[6] = (char)('0' + (y % 10));
+        for (int i = 7; i < 12; i++)
+            digits[i] = (char)('0' + rng.Next(10));
+        digits[12] = (char)('0' + ComputeCheckDigit(digits[..12]));
+        written = 13;
+        return true;
+    }
+
+    private static int ComputeCheckDigit(ReadOnlySpan<char> digits)
+    {
+        int sum = 0;
+        for (int i = 0; i < Weights.Length; i++)
+            sum += (digits[i] - '0') * Weights[i];
+        int r = 11 - (sum % 11);
+        if (r == 10 || r == 11) return 0;
+        return r;
+    }
+
+    private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
+    {
+        len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
+        }
+        return true;
+    }
+}
+

--- a/src/Veritas/Tax/HU/Adoszam.cs
+++ b/src/Veritas/Tax/HU/Adoszam.cs
@@ -1,0 +1,99 @@
+using System;
+using Veritas.Algorithms;
+
+namespace Veritas.Tax.HU;
+
+/// <summary>Hungary VAT number (Adószám) identifier (8+1+2 digits, weighted mod-10 checksum).</summary>
+public static class Adoszam
+{
+    /// <summary>Attempts to validate the supplied input as a Hungarian VAT (Adószám) number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<AdoszamValue> result)
+    {
+        Span<char> digits = stackalloc char[11];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-')
+                continue;
+            if (ch < '0' || ch > '9')
+            {
+                result = new ValidationResult<AdoszamValue>(false, default, ValidationError.Charset);
+                return false;
+            }
+            if (len >= 11)
+            {
+                result = new ValidationResult<AdoszamValue>(false, default, ValidationError.Length);
+                return false;
+            }
+            digits[len++] = ch;
+        }
+        if (len != 11)
+        {
+            result = new ValidationResult<AdoszamValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        int sum = 0;
+        int[] weights = { 9, 7, 3, 1, 9, 7, 3 };
+        for (int i = 0; i < 7; i++)
+            sum += (digits[i] - '0') * weights[i];
+        int check = (10 - (sum % 10)) % 10;
+        if (digits[7] - '0' != check)
+        {
+            result = new ValidationResult<AdoszamValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        // basic VAT and county code range checks
+        if (digits[8] == '0')
+        {
+            result = new ValidationResult<AdoszamValue>(false, default, ValidationError.Format);
+            return false;
+        }
+        if (digits[9] == '0' && digits[10] == '0')
+        {
+            result = new ValidationResult<AdoszamValue>(false, default, ValidationError.Format);
+            return false;
+        }
+        result = new ValidationResult<AdoszamValue>(true, new AdoszamValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a synthetic Hungarian VAT (Adószám) number.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a synthetic Hungarian VAT (Adószám) number.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 11)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        int[] weights = { 9, 7, 3, 1, 9, 7, 3 };
+        for (int i = 0; i < 7; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        int sum = 0;
+        for (int i = 0; i < 7; i++)
+            sum += (destination[i] - '0') * weights[i];
+        destination[7] = (char)('0' + (10 - (sum % 10)) % 10);
+        destination[8] = (char)('1' + rng.Next(9));
+        int county = rng.Next(1, 21);
+        destination[9] = (char)('0' + county / 10);
+        destination[10] = (char)('0' + county % 10);
+        written = 11;
+        return true;
+    }
+}
+
+/// <summary>Represents a validated Hungarian VAT (Adószám) number.</summary>
+public readonly struct AdoszamValue
+{
+    /// <summary>Gets the normalized Adószám string.</summary>
+    public string Value { get; }
+
+    /// <summary>Creates a new <see cref="AdoszamValue"/>.</summary>
+    public AdoszamValue(string value) => Value = value;
+
+    public override string ToString() => Value;
+}

--- a/src/Veritas/Tax/MK/Embg.cs
+++ b/src/Veritas/Tax/MK/Embg.cs
@@ -1,0 +1,101 @@
+using System;
+using Veritas;
+
+namespace Veritas.Tax.MK;
+
+/// <summary>Represents a validated North Macedonia EMBG number.</summary>
+public readonly struct EmbgValue
+{
+    /// <summary>Gets the normalized EMBG string.</summary>
+    public string Value { get; }
+
+    /// <summary>Creates a new <see cref="EmbgValue"/>.</summary>
+    public EmbgValue(string value) => Value = value;
+
+    /// <inheritdoc />
+    public override string ToString() => Value;
+}
+
+/// <summary>
+/// North Macedonia EMBG personal number (13 digits, mod-11 checksum).
+/// </summary>
+public static class Embg
+{
+    private static readonly int[] Weights = { 7, 6, 5, 4, 3, 2, 7, 6, 5, 4, 3, 2 };
+    /// <summary>Attempts to validate the supplied input as a North Macedonia EMBG number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<EmbgValue> result)
+    {
+        Span<char> digits = stackalloc char[13];
+        if (!Normalize(input, digits, out int len))
+        {
+            result = new ValidationResult<EmbgValue>(false, default, ValidationError.Format);
+            return false;
+        }
+        if (len != 13)
+        {
+            result = new ValidationResult<EmbgValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        int check = ComputeCheckDigit(digits[..12]);
+        if (digits[12] - '0' != check)
+        {
+            result = new ValidationResult<EmbgValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<EmbgValue>(true, new EmbgValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a synthetic North Macedonia EMBG number.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a synthetic North Macedonia EMBG number.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        written = 0;
+        if (destination.Length < 13) return false;
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        Span<char> digits = destination[..13];
+        int year = rng.Next(1900, 2100);
+        int month = rng.Next(1, 13);
+        int day = rng.Next(1, DateTime.DaysInMonth(year, month) + 1);
+        digits[0] = (char)('0' + (day / 10));
+        digits[1] = (char)('0' + (day % 10));
+        digits[2] = (char)('0' + (month / 10));
+        digits[3] = (char)('0' + (month % 10));
+        int y = year % 1000;
+        digits[4] = (char)('0' + (y / 100));
+        digits[5] = (char)('0' + (y / 10 % 10));
+        digits[6] = (char)('0' + (y % 10));
+        for (int i = 7; i < 12; i++)
+            digits[i] = (char)('0' + rng.Next(10));
+        digits[12] = (char)('0' + ComputeCheckDigit(digits[..12]));
+        written = 13;
+        return true;
+    }
+
+    private static int ComputeCheckDigit(ReadOnlySpan<char> digits)
+    {
+        int sum = 0;
+        for (int i = 0; i < Weights.Length; i++)
+            sum += (digits[i] - '0') * Weights[i];
+        int r = 11 - (sum % 11);
+        if (r == 10 || r == 11) return 0;
+        return r;
+    }
+
+    private static bool Normalize(ReadOnlySpan<char> input, Span<char> dest, out int len)
+    {
+        len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (!char.IsDigit(ch)) { len = 0; return false; }
+            if (len >= dest.Length) { len = 0; return false; }
+            dest[len++] = ch;
+        }
+        return true;
+    }
+}
+

--- a/test/Veritas.Tests/Finance/BE/OgmTests.cs
+++ b/test/Veritas.Tests/Finance/BE/OgmTests.cs
@@ -1,0 +1,29 @@
+using Veritas.Finance.BE;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class OgmTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[12];
+        Ogm.TryGenerate(new GenerationOptions { Seed = 123 }, dst, out var written).ShouldBeTrue();
+        var s = new string(dst[..written]);
+        Ogm.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("+++123/4567/89002+++", true)]
+    [InlineData("123456789002", true)]
+    [InlineData("123456789001", false)]
+    [InlineData("1234567890", false)]
+    [InlineData("123/4567/8900X", false)]
+    public void Validate_Known(string input, bool expected)
+    {
+        Ogm.TryValidate(input, out var r).ShouldBe(expected);
+        r.IsValid.ShouldBe(expected);
+    }
+}

--- a/test/Veritas.Tests/Identity/France/NirTests.cs
+++ b/test/Veritas.Tests/Identity/France/NirTests.cs
@@ -1,0 +1,29 @@
+using Veritas.Identity.France;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class NirTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[15];
+        Nir.TryGenerate(new GenerationOptions { Seed = 42 }, dst, out var written).ShouldBeTrue();
+        var s = new string(dst[..written]);
+        Nir.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("1 00 01 2A 001 001 74", true)]
+    [InlineData("123456789012311", true)]
+    [InlineData("100012A00100175", false)]
+    [InlineData("100012A0010017X", false)]
+    [InlineData("100012A001001", false)]
+    public void Validate_Known(string input, bool expected)
+    {
+        Nir.TryValidate(input, out var r).ShouldBe(expected);
+        r.IsValid.ShouldBe(expected);
+    }
+}

--- a/test/Veritas.Tests/Iso7064Tests.cs
+++ b/test/Veritas.Tests/Iso7064Tests.cs
@@ -55,4 +55,23 @@ public class Iso7064Tests
         Iso7064.ValidateMod37_2(full).ShouldBeTrue();
         Iso7064.ValidateMod37_2(baseStr + (check == '0' ? '1' : '0')).ShouldBeFalse();
     }
+
+    [Theory]
+    [InlineData("ABC", 'Z')]
+    [InlineData("123456", 'J')]
+    public void ComputeCheckCharacterMod37_36_Works(string input, char expected)
+    {
+        var check = Iso7064.ComputeCheckCharacterMod37_36(input.AsSpan());
+        check.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData("ABCZ", true)]
+    [InlineData("123456J", true)]
+    [InlineData("ABC0", false)]
+    [InlineData("", false)]
+    public void ValidateMod37_36_Works(string input, bool expected)
+    {
+        Iso7064.ValidateMod37_36(input).ShouldBe(expected);
+    }
 }

--- a/test/Veritas.Tests/Logistics/GraiTests.cs
+++ b/test/Veritas.Tests/Logistics/GraiTests.cs
@@ -1,0 +1,24 @@
+using Shouldly;
+using Veritas.Logistics;
+using Xunit;
+
+namespace Veritas.Tests.Logistics;
+
+public class GraiTests
+{
+    [Theory]
+    [InlineData("12345678901231", true)]
+    [InlineData("12345678901232", false)]
+    [InlineData("1234567890123", false)]
+    [InlineData("1234567890123A", false)]
+    public void Validate_Works(string input, bool expected)
+        => Grai.TryValidate(input, out var r).ShouldBe(expected);
+
+    [Fact]
+    public void Generate_RoundTrips()
+    {
+        Span<char> buffer = stackalloc char[14];
+        Grai.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Grai.TryValidate(buffer[..written], out var r).ShouldBeTrue();
+    }
+}

--- a/test/Veritas.Tests/Logistics/GsinTests.cs
+++ b/test/Veritas.Tests/Logistics/GsinTests.cs
@@ -1,0 +1,24 @@
+using Shouldly;
+using Veritas.Logistics;
+using Xunit;
+
+namespace Veritas.Tests.Logistics;
+
+public class GsinTests
+{
+    [Theory]
+    [InlineData("12345678901234560", true)]
+    [InlineData("12345678901234561", false)]
+    [InlineData("1234567890123456", false)]
+    [InlineData("1234567890123456A", false)]
+    public void Validate_Works(string input, bool expected)
+        => Gsin.TryValidate(input, out var r).ShouldBe(expected);
+
+    [Fact]
+    public void Generate_RoundTrips()
+    {
+        Span<char> buffer = stackalloc char[17];
+        Gsin.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Gsin.TryValidate(buffer[..written], out var r).ShouldBeTrue();
+    }
+}

--- a/test/Veritas.Tests/Logistics/GsrnTests.cs
+++ b/test/Veritas.Tests/Logistics/GsrnTests.cs
@@ -1,0 +1,24 @@
+using Shouldly;
+using Veritas.Logistics;
+using Xunit;
+
+namespace Veritas.Tests.Logistics;
+
+public class GsrnTests
+{
+    [Theory]
+    [InlineData("123456789012345675", true)]
+    [InlineData("123456789012345674", false)]
+    [InlineData("12345678901234567", false)]
+    [InlineData("12345678901234567A", false)]
+    public void Validate_Works(string input, bool expected)
+        => Gsrn.TryValidate(input, out var r).ShouldBe(expected);
+
+    [Fact]
+    public void Generate_RoundTrips()
+    {
+        Span<char> buffer = stackalloc char[18];
+        Gsrn.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Gsrn.TryValidate(buffer[..written], out var r).ShouldBeTrue();
+    }
+}

--- a/test/Veritas.Tests/LuhnTests.cs
+++ b/test/Veritas.Tests/LuhnTests.cs
@@ -22,4 +22,42 @@ public class LuhnTests
         var check = Luhn.ComputeCheckDigit(digits);
         check.ShouldBe(3);
     }
+
+    [Theory]
+    [InlineData("ABCDEFU", true)]
+    [InlineData("ABCDEFX", false)]
+    [InlineData("ABC#DEF", false)]
+    [InlineData("", false)]
+    public void ValidateBase36_Works(string input, bool expected)
+    {
+        Luhn.ValidateBase36(input).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ComputeCheckCharacterBase36_ProducesExpected()
+    {
+        var check = Luhn.ComputeCheckCharacterBase36("ABCDEF".AsSpan());
+        check.ShouldBe('U');
+    }
+
+    [Fact]
+    public void Base36_RoundTripRandom()
+    {
+        var rng = new Random(123);
+        Span<char> buf = stackalloc char[32];
+        Span<char> total = stackalloc char[33];
+        for (int i = 0; i < 100; i++)
+        {
+            int len = rng.Next(1, 20);
+            for (int j = 0; j < len; j++)
+            {
+                int v = rng.Next(36);
+                buf[j] = v < 10 ? (char)('0' + v) : (char)('A' + v - 10);
+            }
+            var check = Luhn.ComputeCheckCharacterBase36(buf[..len]);
+            buf[..len].CopyTo(total);
+            total[len] = check;
+            Luhn.ValidateBase36(total[..(len + 1)]).ShouldBeTrue();
+        }
+    }
 }

--- a/test/Veritas.Tests/Mod11Tests.cs
+++ b/test/Veritas.Tests/Mod11Tests.cs
@@ -12,5 +12,41 @@ public class Mod11Tests
         int[] weights = { 5, 4, 3, 2, 1 };
         Mod11.ComputeMod11(digits, weights).ShouldBe(2);
     }
+
+    [Fact]
+    public void ComputeCheckCharacter_FromRightPattern()
+    {
+        int[] weights = { 2, 3, 4, 5, 6, 7 };
+        var check = Mod11.ComputeCheckCharacter("123456789".AsSpan(), weights, fromRight: true);
+        check.ShouldBe('2');
+    }
+
+    [Theory]
+    [InlineData("1234567892", true)]
+    [InlineData("1234567890", false)]
+    public void Validate_FromRightPattern(string input, bool expected)
+    {
+        int[] weights = { 2, 3, 4, 5, 6, 7 };
+        Mod11.Validate(input, weights, fromRight: true).ShouldBe(expected);
+    }
+
+    [Fact]
+    public void ComputeCheckCharacter_IsbnExample()
+    {
+        int[] weights = { 10, 9, 8, 7, 6, 5, 4, 3, 2 };
+        var check = Mod11.ComputeCheckCharacter("097522980".AsSpan(), weights);
+        check.ShouldBe('X');
+    }
+
+    [Theory]
+    [InlineData("097522980X", true)]
+    [InlineData("0975229800", false)]
+    [InlineData("", false)]
+    [InlineData("09752298#X", false)]
+    public void Validate_IsbnExample(string input, bool expected)
+    {
+        int[] weights = { 10, 9, 8, 7, 6, 5, 4, 3, 2 };
+        Mod11.Validate(input, weights).ShouldBe(expected);
+    }
 }
 

--- a/test/Veritas.Tests/Tax/BA/JmbgTests.cs
+++ b/test/Veritas.Tests/Tax/BA/JmbgTests.cs
@@ -1,0 +1,35 @@
+using Shouldly;
+using Veritas.Tax.BA;
+using Xunit;
+
+namespace Veritas.Tests.Tax.BA;
+
+public class JmbgTests
+{
+    [Fact]
+    public void GenerateRoundTrip()
+    {
+        Span<char> dst = stackalloc char[13];
+        Jmbg.TryGenerate(new GenerationOptions { Seed = 123 }, dst, out var written).ShouldBeTrue();
+        var s = new string(dst[..written]);
+        Jmbg.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("0101006500006")]
+    public void ValidateKnownGood(string input)
+    {
+        Jmbg.TryValidate(input, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("0101006500007")]
+    [InlineData("abcdefghijklm")]
+    public void ValidateBad(string input)
+    {
+        Jmbg.TryValidate(input, out var r).ShouldBeFalse();
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/Tax/HU/AdoszamTests.cs
+++ b/test/Veritas.Tests/Tax/HU/AdoszamTests.cs
@@ -1,0 +1,28 @@
+using Shouldly;
+using Veritas.Tax.HU;
+using Xunit;
+
+namespace Veritas.Tests.Tax.HU;
+
+public class AdoszamTests
+{
+    [Theory]
+    [InlineData("12345676-1-31", true)]
+    [InlineData("12345675-1-31", false)]
+    [InlineData("12345A76-1-31", false)]
+    [InlineData("12345676131", true)]
+    public void Validate_Works(string input, bool expected)
+    {
+        Adoszam.TryValidate(input, out var result).ShouldBe(expected);
+        if (expected)
+            result.Value!.Value.ShouldBe("12345676131");
+    }
+
+    [Fact]
+    public void Generate_RoundTrips()
+    {
+        Span<char> buffer = stackalloc char[11];
+        Adoszam.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Adoszam.TryValidate(buffer[..written], out var result).ShouldBeTrue();
+    }
+}

--- a/test/Veritas.Tests/Tax/MK/EmbgTests.cs
+++ b/test/Veritas.Tests/Tax/MK/EmbgTests.cs
@@ -1,0 +1,35 @@
+using Shouldly;
+using Veritas.Tax.MK;
+using Xunit;
+
+namespace Veritas.Tests.Tax.MK;
+
+public class EmbgTests
+{
+    [Fact]
+    public void GenerateRoundTrip()
+    {
+        Span<char> dst = stackalloc char[13];
+        Embg.TryGenerate(new GenerationOptions { Seed = 123 }, dst, out var written).ShouldBeTrue();
+        var s = new string(dst[..written]);
+        Embg.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("0101006500006")]
+    public void ValidateKnownGood(string input)
+    {
+        Embg.TryValidate(input, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData("0101006500007")]
+    [InlineData("abcdefghijklm")]
+    public void ValidateBad(string input)
+    {
+        Embg.TryValidate(input, out var r).ShouldBeFalse();
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/Tax/NO/KidTests.cs
+++ b/test/Veritas.Tests/Tax/NO/KidTests.cs
@@ -1,4 +1,5 @@
 using Veritas.Tax.NO;
+using Veritas;
 using Xunit;
 using Shouldly;
 
@@ -28,7 +29,7 @@ public class NoKidTests
     public void Generate_Mod11_Valid()
     {
         Span<char> buffer = stackalloc char[5];
-        Kid.TryGenerate(KidVariant.Mod11, 5, buffer, out var written).ShouldBeTrue();
+        Kid.TryGenerate(KidVariant.Mod11, new GenerationOptions { Seed = 1 }, 5, buffer, out var written).ShouldBeTrue();
         Kid.TryValidate(buffer[..written], KidVariant.Mod11, out var result).ShouldBeTrue();
         result.IsValid.ShouldBeTrue();
     }


### PR DESCRIPTION
## Summary
- introduce `IChecksum` abstraction with reusable strategies for Luhn, GS1 mod 10, weighted mod 11, and ISO 7064
- add transliteration helpers and Belgian structured reference (OGM) identifier
- fix Australian TFN generator to avoid invalid check digits
- implement French NIR (INSEE) identifier
- extend base-36 Luhn support and validation
- add Hungarian VAT (Adószám) and GS1 GSRN identifiers
- stabilize Norwegian KID tests with deterministic seeds
- add Bosnia and Herzegovina JMBG and North Macedonia EMBG personal numbers
- add GS1 GRAI and GSIN validation and generation

## Testing
- `dotnet format --verify-no-changes --verbosity normal`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c5497580d8832bb17e02d1661ce1ae