### PR TITLE
Implement identifiers from PRD-Extensions-3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,17 @@
 - Public APIs must include XML documentation comments.
 - Favor span-based, allocation-free implementations and `TryValidate`/`TryGenerate` patterns.
 - PR descriptions must include a **Summary** of changes and a **Testing** section with executed commands.
+
+## Definition of Done
+
+- Each identifier ships with a parser/normalizer and deterministic checksum.
+- Generators produce valid examples using `GenerationOptions` and are covered by positive/negative tests.
+- Public APIs include XML docs with a one-line summary and example usage.
+- `README.md` and `docfx/index.md` list newly added identifiers and DocFX builds cleanly.
+
+## Coding Style
+
+- Prefer `ReadOnlySpan<char>`/`Span<char>` over `string` to minimize allocations.
+- Expose `TryValidate`/`TryGenerate` methods returning `bool` and `out` parameters for normalized values.
+- Implement value types as `readonly struct` with canonical `ToString()` representations.
+- Avoid LINQ and heap allocations in hot paths; use simple loops and `stackalloc` where appropriate.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ dotnet add package Veritas --version 1.0.3
 - ISIN validation (alphabetic + numeric with Luhn check digit)
 - ISO 11649 RF creditor reference validation and generation
 - Belgium structured communication (OGM) validation and generation
+- SEPA Creditor Identifier (SCI) validation and generation
+- French RIB key validation and generation
+- Spanish CCC validation and generation
 - Payment card PAN validation (Luhn)
 - US ABA routing number validation
 - Mexican CLABE validation and generation
@@ -71,6 +74,7 @@ dotnet add package Veritas --version 1.0.3
 - India Aadhaar validation and generation
 - Luxembourg National ID validation and generation
 - France NIR (INSEE) validation and generation
+- ICAO 9303 MRZ passport lines validation and generation
 
 ### Tax
 - Brazil CPF validation/generation
@@ -141,6 +145,7 @@ dotnet add package Veritas --version 1.0.3
 - Singapore UEN validation/generation
 - South Africa National ID validation/generation
 - Israel Teudat Zehut validation/generation
+- EU/GB EORI validation and generation
 
 ### Logistics
 - GTIN/EAN/UPC validation and generation (GS1 mod 10)
@@ -149,6 +154,9 @@ dotnet add package Veritas --version 1.0.3
 - Global Service Relation Number (GSRN) validation and generation
 - Global Returnable Asset Identifier (GRAI) validation and generation
 - Global Shipment Identification Number (GSIN) validation and generation
+- Global Document Type Identifier (GDTI) validation and generation
+- Global Individual Asset Identifier (GIAI) validation and generation
+- UPU S10 postal tracking validation and generation
 - Vehicle Identification Number (VIN) validation
 - ISO 6346 container code validation
 - Air Waybill (AWB) validation and generation
@@ -156,6 +164,7 @@ dotnet add package Veritas --version 1.0.3
 
 ### Telecom
 - IMEI validation and generation
+- IMSI validation and generation
 - MEID validation and generation
 - ICCID validation and generation
 - MAC address validation and generation
@@ -180,6 +189,8 @@ dotnet add package Veritas --version 1.0.3
 - NHS Number validation and generation
 - ORCID validation and generation
 - SNOMED CT Concept ID validation and generation
+- NPI validation and generation
+- DEA Number validation and generation
 
 Additional identifiers and algorithms will be added per the [PRD](prds/PRD.md).
 

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -64,7 +64,10 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | BIC/SWIFT | International | format check | <xref:Veritas.Finance.Bic> |
 | ISIN | International | Luhn checksum | <xref:Veritas.Finance.Isin> |
 | RF Creditor Reference | International | ISO 11649 mod 97; generation | <xref:Veritas.Finance.Rf> |
+| SEPA Creditor Identifier | EU | ISO 7064 mod 97 checksum; generation | <xref:Veritas.Finance.SepaCreditorIdentifier> |
 | Structured Reference (OGM) | BE | mod 97 checksum; generation | <xref:Veritas.Finance.BE.Ogm> |
+| RIB | FR | mod 97 checksum; generation | <xref:Veritas.Finance.FR.Rib> |
+| CCC | ES | dual mod 11 checksum; generation | <xref:Veritas.Finance.ES.Ccc> |
 | Payment card PAN | International | Luhn checksum; test generation | <xref:Veritas.Finance.Pan> |
 | ABA Routing | US | weighted mod 11 checksum | <xref:Veritas.Finance.AbaRouting> |
 | CLABE | Mexico | weighted mod 11 checksum; generation | <xref:Veritas.Finance.Clabe> |
@@ -110,11 +113,13 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | National ID | South Africa | Luhn checksum; generation | <xref:Veritas.Identity.SouthAfrica.NationalId> |
 | Teudat Zehut | Israel | weighted mod 10 checksum; generation | <xref:Veritas.Identity.Israel.TeudatZehut> |
 | NIR (INSEE) | France | mod 97 key; generation | <xref:Veritas.Identity.France.Nir> |
+| ICAO MRZ (TD3) | Global | MRZ checksums; generation | <xref:Veritas.Identity.IcaoMrz> |
 
 ### Tax
 
 | Country | Identifier | Validation & Generation | Docs |
 |---------|------------|-------------------------|------|
+| EU/GB | EORI | structural check; generation | <xref:Veritas.Tax.Eori> |
 | AR | CUIT | mod 11 checksum; generation | <xref:Veritas.Tax.AR.Cuit> |
 | AU | ABN | weighted mod 11 checksum; generation | <xref:Veritas.Tax.AU.Abn> |
 | AU | TFN | weighted mod 11 checksum; generation | <xref:Veritas.Tax.AU.Tfn> |
@@ -192,6 +197,9 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | GSRN | International | GS1 mod 10 checksum; generation | <xref:Veritas.Logistics.Gsrn> |
 | GRAI | International | GS1 mod 10 checksum; generation | <xref:Veritas.Logistics.Grai> |
 | GSIN | International | GS1 mod 10 checksum; generation | <xref:Veritas.Logistics.Gsin> |
+| GDTI | International | GS1 mod 10 checksum; generation | <xref:Veritas.Logistics.Gdti> |
+| GIAI | International | structural check; generation | <xref:Veritas.Logistics.Giai> |
+| UPU S10 | International | weighted mod 11 checksum; generation | <xref:Veritas.Logistics.UpuS10> |
 | VIN | International | transliteration + weighted checksum | <xref:Veritas.Logistics.Vin> |
 | ISO 6346 | International | ISO 6346 checksum | <xref:Veritas.Logistics.Iso6346> |
 | AWB | International | mod 7 checksum; generation | <xref:Veritas.Logistics.Awb> |
@@ -202,6 +210,7 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | Identifier | Country/Region | Validation & Generation | Docs |
 |------------|----------------|-------------------------|------|
 | IMEI | Global | Luhn checksum; generation | <xref:Veritas.Telecom.Imei> |
+| IMSI | Global | structural check; generation | <xref:Veritas.Telecom.Imsi> |
 | MEID | Global | Luhn checksum; generation | <xref:Veritas.Telecom.Meid> |
 | ICCID | Global | Luhn checksum; generation | <xref:Veritas.Telecom.Iccid> |
 | MAC | Global | format + OUI | <xref:Veritas.Telecom.Mac> |
@@ -235,6 +244,8 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | NHS Number | UK | mod 11 checksum; generation | <xref:Veritas.Healthcare.NhsNumber> |
 | ORCID | International | ISO 7064 mod 11,2 checksum; generation | <xref:Veritas.Healthcare.Orcid> |
 | SNOMED CT Concept ID | International | Verhoeff checksum; test generation | <xref:Veritas.Healthcare.Snomed.SctId> |
+| NPI | US | Luhn checksum; generation | <xref:Veritas.Healthcare.Npi> |
+| DEA Number | US | weighted checksum; generation | <xref:Veritas.Healthcare.DeaNumber> |
 
 ## Future identifiers
 
@@ -251,10 +262,8 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 
 ### Identity & Telecom
 - OpenID Connect subject identifiers
-- IMSI (mobile subscriber identities)
 
 ### Logistics
-- UPU S10 postal tracking
 
 Contributions for these and other identifiers are welcome!
 

--- a/prds/PRD-Extensions-3.md
+++ b/prds/PRD-Extensions-3.md
@@ -154,3 +154,7 @@ Continue your established pattern:
     `test/Veritas.Tests/<Sector>/<Country?>/<Identifier>Tests.cs`.\
 -   ✅ Optional: register each identifier in a metadata catalog so
     docs/website can auto-list.
+
+## Status
+
+All identifiers listed above have been implemented.

--- a/src/Veritas/Finance/ES/Ccc.cs
+++ b/src/Veritas/Finance/ES/Ccc.cs
@@ -1,0 +1,91 @@
+using System;
+using Veritas;
+
+namespace Veritas.Finance.ES;
+
+/// <summary>Spanish bank account code (CCC) consisting of bank, branch, control digits, and account number.</summary>
+public readonly struct CccValue
+{
+    /// <summary>The normalized CCC string.</summary>
+    public string Value { get; }
+    public CccValue(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for Spanish CCC numbers.</summary>
+public static class Ccc
+{
+    /// <summary>Attempts to validate the supplied CCC.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<CccValue> result)
+    {
+        Span<char> digits = stackalloc char[20];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (ch < '0' || ch > '9' || len >= 20)
+            {
+                result = new ValidationResult<CccValue>(false, default, ValidationError.Charset);
+                return false;
+            }
+            digits[len++] = ch;
+        }
+        if (len != 20)
+        {
+            result = new ValidationResult<CccValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        int cd1 = digits[8] - '0';
+        int cd2 = digits[9] - '0';
+        if (ComputeBankBranch(digits[..8]) != cd1 || ComputeAccount(digits[10..]) != cd2)
+        {
+            result = new ValidationResult<CccValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<CccValue>(true, new CccValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a valid CCC into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a valid CCC using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 20)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 8; i++) destination[i] = (char)('0' + rng.Next(10));
+        for (int i = 10; i < 20; i++) destination[i] = (char)('0' + rng.Next(10));
+        destination[8] = (char)('0' + ComputeBankBranch(destination[..8]));
+        destination[9] = (char)('0' + ComputeAccount(destination[10..]));
+        written = 20;
+        return true;
+    }
+
+    private static int ComputeBankBranch(ReadOnlySpan<char> span)
+    {
+        int[] weights = { 4, 8, 5, 10, 9, 7, 3, 6 };
+        int sum = 0;
+        for (int i = 0; i < 8; i++) sum += (span[i] - '0') * weights[i];
+        int mod = 11 - (sum % 11);
+        if (mod == 10) return 1;
+        if (mod == 11) return 0;
+        return mod;
+    }
+
+    private static int ComputeAccount(ReadOnlySpan<char> span)
+    {
+        int[] weights = { 1, 2, 4, 8, 5, 10, 9, 7, 3, 6 };
+        int sum = 0;
+        for (int i = 0; i < 10; i++) sum += (span[i] - '0') * weights[i];
+        int mod = 11 - (sum % 11);
+        if (mod == 10) return 1;
+        if (mod == 11) return 0;
+        return mod;
+    }
+}
+

--- a/src/Veritas/Finance/FR/Rib.cs
+++ b/src/Veritas/Finance/FR/Rib.cs
@@ -1,0 +1,140 @@
+using System;
+using Veritas;
+
+namespace Veritas.Finance.FR;
+
+/// <summary>French RIB (Relevé d'Identité Bancaire) including the two-digit key.</summary>
+public readonly struct RibValue
+{
+    /// <summary>The normalized RIB string.</summary>
+    public string Value { get; }
+    public RibValue(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for French RIB numbers.</summary>
+public static class Rib
+{
+    /// <summary>Validates the supplied RIB.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<RibValue> result)
+    {
+        Span<char> buffer = stackalloc char[23];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (len >= buffer.Length) { result = new ValidationResult<RibValue>(false, default, ValidationError.Length); return false; }
+            buffer[len++] = char.IsLower(ch) ? (char)(ch - 32) : ch;
+        }
+        if (len != 23)
+        {
+            result = new ValidationResult<RibValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        for (int i = 0; i < 5; i++)
+            if (buffer[i] < '0' || buffer[i] > '9') { result = new ValidationResult<RibValue>(false, default, ValidationError.Charset); return false; }
+        for (int i = 5; i < 10; i++)
+            if (buffer[i] < '0' || buffer[i] > '9') { result = new ValidationResult<RibValue>(false, default, ValidationError.Charset); return false; }
+        for (int i = 10; i < 21; i++)
+        {
+            char c = buffer[i];
+            if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+            if (!((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z'))) { result = new ValidationResult<RibValue>(false, default, ValidationError.Charset); return false; }
+            buffer[i] = c;
+        }
+        if (buffer[21] < '0' || buffer[21] > '9' || buffer[22] < '0' || buffer[22] > '9')
+        {
+            result = new ValidationResult<RibValue>(false, default, ValidationError.Charset);
+            return false;
+        }
+        int bank = ParseInt(buffer[..5]);
+        int branch = ParseInt(buffer.Slice(5, 5));
+        long account = ParseAccount(buffer.Slice(10, 11));
+        int expected = 97 - (int)((89L * bank + 15L * branch + 3L * account) % 97L);
+        int key = (buffer[21] - '0') * 10 + (buffer[22] - '0');
+        if (expected == 0) expected = 97;
+        if (expected != key)
+        {
+            result = new ValidationResult<RibValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<RibValue>(true, new RibValue(new string(buffer)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a valid RIB into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a valid RIB using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 23)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 5; i++) destination[i] = (char)('0' + rng.Next(10));
+        for (int i = 5; i < 10; i++) destination[i] = (char)('0' + rng.Next(10));
+        for (int i = 10; i < 21; i++) destination[i] = (char)('0' + rng.Next(10));
+        int bank = ParseInt(destination[..5]);
+        int branch = ParseInt(destination.Slice(5, 5));
+        long account = ParseAccount(destination.Slice(10, 11));
+        int key = 97 - (int)((89L * bank + 15L * branch + 3L * account) % 97L);
+        if (key == 0) key = 97;
+        destination[21] = (char)('0' + key / 10);
+        destination[22] = (char)('0' + key % 10);
+        written = 23;
+        return true;
+    }
+
+    private static int ParseInt(ReadOnlySpan<char> digits)
+    {
+        int n = 0;
+        foreach (var ch in digits) n = n * 10 + (ch - '0');
+        return n;
+    }
+
+    private static long ParseAccount(ReadOnlySpan<char> span)
+    {
+        long n = 0;
+        foreach (var ch in span)
+        {
+            int v;
+            if (ch >= '0' && ch <= '9') v = ch - '0';
+            else v = ch switch
+            {
+                'A' => 1,
+                'B' => 2,
+                'C' => 3,
+                'D' => 4,
+                'E' => 5,
+                'F' => 6,
+                'G' => 7,
+                'H' => 8,
+                'I' => 9,
+                'J' => 1,
+                'K' => 2,
+                'L' => 3,
+                'M' => 4,
+                'N' => 5,
+                'O' => 6,
+                'P' => 7,
+                'Q' => 8,
+                'R' => 9,
+                'S' => 2,
+                'T' => 3,
+                'U' => 4,
+                'V' => 5,
+                'W' => 6,
+                'X' => 7,
+                'Y' => 8,
+                'Z' => 9,
+                _ => 0
+            };
+            n = n * 10 + v;
+        }
+        return n;
+    }
+}
+

--- a/src/Veritas/Finance/SepaCreditorIdentifier.cs
+++ b/src/Veritas/Finance/SepaCreditorIdentifier.cs
@@ -1,0 +1,117 @@
+using System;
+using Veritas.Algorithms;
+using Veritas;
+
+namespace Veritas.Finance;
+
+/// <summary>Represents a validated SEPA Creditor Identifier.</summary>
+/// <example>SepaCreditorIdentifier.TryValidate("DE74ZZZ09999999999", out var value);</example>
+public readonly struct SepaCreditorIdentifierValue
+{
+    /// <summary>The normalized SEPA Creditor Identifier string.</summary>
+    public string Value { get; }
+    public SepaCreditorIdentifierValue(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for SEPA Creditor Identifiers.</summary>
+public static class SepaCreditorIdentifier
+{
+    /// <summary>Validates the supplied SEPA Creditor Identifier.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<SepaCreditorIdentifierValue> result)
+    {
+        Span<char> buffer = stackalloc char[35];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            char c = ch;
+            if (len < 2)
+            {
+                if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+                if (c < 'A' || c > 'Z') { result = new ValidationResult<SepaCreditorIdentifierValue>(false, default, ValidationError.Charset); return false; }
+            }
+            else if (len < 4)
+            {
+                if (c < '0' || c > '9') { result = new ValidationResult<SepaCreditorIdentifierValue>(false, default, ValidationError.Charset); return false; }
+            }
+            else
+            {
+                if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+                if (!((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z'))) { result = new ValidationResult<SepaCreditorIdentifierValue>(false, default, ValidationError.Charset); return false; }
+            }
+            if (len >= buffer.Length) { result = new ValidationResult<SepaCreditorIdentifierValue>(false, default, ValidationError.Length); return false; }
+            buffer[len++] = c;
+        }
+        if (len < 8)
+        {
+            result = new ValidationResult<SepaCreditorIdentifierValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        Span<char> digits = stackalloc char[70];
+        int idx = 0;
+        for (int i = 4; i < len; i++) Append(digits, ref idx, buffer[i]);
+        for (int i = 0; i < 4; i++) Append(digits, ref idx, buffer[i]);
+        if (Iso7064.ComputeMod97(digits[..idx]) != 1)
+        {
+            result = new ValidationResult<SepaCreditorIdentifierValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<SepaCreditorIdentifierValue>(true, new SepaCreditorIdentifierValue(new string(buffer[..len])), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a valid SEPA Creditor Identifier into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a valid SEPA Creditor Identifier using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        var cc = _countryCodes[rng.Next(_countryCodes.Length)];
+        int nationalLen = 5 + rng.Next(15); // 5..19
+        int total = 7 + nationalLen;
+        if (destination.Length < total)
+        {
+            written = 0;
+            return false;
+        }
+        destination[0] = cc[0];
+        destination[1] = cc[1];
+        destination[2] = destination[3] = '0';
+        destination[4] = destination[5] = destination[6] = 'Z';
+        for (int i = 0; i < nationalLen; i++)
+            destination[7 + i] = (char)('0' + rng.Next(10));
+        Span<char> digits = stackalloc char[70];
+        int idx = 0;
+        for (int i = 4; i < total; i++) Append(digits, ref idx, destination[i]);
+        Append(digits, ref idx, destination[0]);
+        Append(digits, ref idx, destination[1]);
+        Append(digits, ref idx, '0');
+        Append(digits, ref idx, '0');
+        int check = 98 - Iso7064.ComputeMod97(digits[..idx]);
+        destination[2] = (char)('0' + check / 10);
+        destination[3] = (char)('0' + check % 10);
+        written = total;
+        return true;
+    }
+
+    private static void Append(Span<char> dest, ref int idx, char ch)
+    {
+        if (ch >= 'A' && ch <= 'Z')
+        {
+            int v = ch - 'A' + 10;
+            dest[idx++] = (char)('0' + v / 10);
+            dest[idx++] = (char)('0' + v % 10);
+        }
+        else
+        {
+            dest[idx++] = ch;
+        }
+    }
+
+    private static readonly string[] _countryCodes = new[]
+    {
+        "AT","BE","BG","CY","CZ","DE","DK","EE","ES","FI","FR","GR","HR","HU","IE","IT","LT","LU","LV","MT","NL","PL","PT","RO","SE","SI","SK","GB"
+    };
+}

--- a/src/Veritas/Healthcare/DeaNumber.cs
+++ b/src/Veritas/Healthcare/DeaNumber.cs
@@ -1,0 +1,101 @@
+using System;
+
+namespace Veritas.Healthcare;
+
+/// <summary>Represents a validated U.S. DEA registration number.</summary>
+/// <example>DeaNumber.TryValidate("AB1234563", out var result);</example>
+public readonly struct DeaNumberValue
+{
+    /// <summary>The normalized DEA number string.</summary>
+    public string Value { get; }
+    public DeaNumberValue(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for U.S. DEA registration numbers.</summary>
+public static class DeaNumber
+{
+    /// <summary>Validates the supplied DEA number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<DeaNumberValue> result)
+    {
+        Span<char> buffer = stackalloc char[9];
+        int len = 0;
+        foreach (var chRaw in input)
+        {
+            char ch = chRaw;
+            if (ch == ' ' || ch == '-') continue;
+            if (len < 2)
+            {
+                if (ch >= 'a' && ch <= 'z') ch = (char)(ch - 32);
+                if ((ch < 'A' || ch > 'Z') && !(len == 1 && ch == '9'))
+                {
+                    result = new ValidationResult<DeaNumberValue>(false, default, ValidationError.Charset);
+                    return false;
+                }
+            }
+            else
+            {
+                if (ch < '0' || ch > '9')
+                {
+                    result = new ValidationResult<DeaNumberValue>(false, default, ValidationError.Charset);
+                    return false;
+                }
+            }
+            if (len >= 9)
+            {
+                result = new ValidationResult<DeaNumberValue>(false, default, ValidationError.Length);
+                return false;
+            }
+            buffer[len++] = ch;
+        }
+        if (len != 9)
+        {
+            result = new ValidationResult<DeaNumberValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        int d1 = buffer[2] - '0';
+        int d2 = buffer[3] - '0';
+        int d3 = buffer[4] - '0';
+        int d4 = buffer[5] - '0';
+        int d5 = buffer[6] - '0';
+        int d6 = buffer[7] - '0';
+        int d7 = buffer[8] - '0';
+        int check = ((d1 + d3 + d5) + 2 * (d2 + d4 + d6)) % 10;
+        if (check != d7)
+        {
+            result = new ValidationResult<DeaNumberValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<DeaNumberValue>(true, new DeaNumberValue(new string(buffer)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a valid DEA number into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a valid DEA number using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 9)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        destination[0] = (char)('A' + rng.Next(26));
+        bool business = rng.Next(2) == 0;
+        destination[1] = business ? '9' : (char)('A' + rng.Next(26));
+        for (int i = 2; i < 8; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        int d1 = destination[2] - '0';
+        int d2 = destination[3] - '0';
+        int d3 = destination[4] - '0';
+        int d4 = destination[5] - '0';
+        int d5 = destination[6] - '0';
+        int d6 = destination[7] - '0';
+        int check = ((d1 + d3 + d5) + 2 * (d2 + d4 + d6)) % 10;
+        destination[8] = (char)('0' + check);
+        written = 9;
+        return true;
+    }
+}

--- a/src/Veritas/Healthcare/Npi.cs
+++ b/src/Veritas/Healthcare/Npi.cs
@@ -1,0 +1,72 @@
+using System;
+using Veritas.Algorithms;
+
+namespace Veritas.Healthcare;
+
+/// <summary>Represents a validated National Provider Identifier.</summary>
+/// <example>Npi.TryValidate("1234567893", out var result);</example>
+public readonly struct NpiValue
+{
+    /// <summary>The normalized NPI string.</summary>
+    public string Value { get; }
+    public NpiValue(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for U.S. National Provider Identifiers.</summary>
+public static class Npi
+{
+    private const string Prefix = "80840";
+
+    /// <summary>Validates the supplied NPI string.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<NpiValue> result)
+    {
+        Span<char> digits = stackalloc char[10];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (ch < '0' || ch > '9') { result = new ValidationResult<NpiValue>(false, default, ValidationError.Charset); return false; }
+            if (len >= 10) { result = new ValidationResult<NpiValue>(false, default, ValidationError.Length); return false; }
+            digits[len++] = ch;
+        }
+        if (len != 10)
+        {
+            result = new ValidationResult<NpiValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        Span<char> buffer = stackalloc char[Prefix.Length + 9];
+        Prefix.AsSpan().CopyTo(buffer);
+        digits[..9].CopyTo(buffer[Prefix.Length..]);
+        int check = Luhn.ComputeCheckDigit(buffer);
+        if (check != digits[9] - '0')
+        {
+            result = new ValidationResult<NpiValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<NpiValue>(true, new NpiValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a valid NPI into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a valid NPI using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 10)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 9; i++) destination[i] = (char)('0' + rng.Next(10));
+        Span<char> buffer = stackalloc char[Prefix.Length + 9];
+        Prefix.AsSpan().CopyTo(buffer);
+        destination[..9].CopyTo(buffer[Prefix.Length..]);
+        int check = Luhn.ComputeCheckDigit(buffer);
+        destination[9] = (char)('0' + check);
+        written = 10;
+        return true;
+    }
+}

--- a/src/Veritas/Identity/IcaoMrz.cs
+++ b/src/Veritas/Identity/IcaoMrz.cs
@@ -1,0 +1,144 @@
+using System;
+using Veritas.Algorithms;
+using Veritas;
+
+namespace Veritas.Identity;
+
+/// <summary>Machine Readable Zone (MRZ) lines compliant with ICAO 9303 TD3 passports.</summary>
+public readonly struct IcaoMrzValue
+{
+    /// <summary>The MRZ string containing two lines separated by a newline.</summary>
+    public string Value { get; }
+    public IcaoMrzValue(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for ICAO 9303 MRZ (TD3) lines.</summary>
+public static class IcaoMrz
+{
+    /// <summary>Validates TD3 (passport) MRZ consisting of two 44-character lines.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<IcaoMrzValue> result)
+    {
+        int nl = input.IndexOf('\n');
+        if (nl <= 0 || nl != input.LastIndexOf('\n'))
+        {
+            result = new ValidationResult<IcaoMrzValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        var line1 = input[..nl];
+        var line2 = input[(nl + 1)..];
+        if (line1.Length != 44 || line2.Length != 44)
+        {
+            result = new ValidationResult<IcaoMrzValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        Span<char> l1 = stackalloc char[44];
+        Span<char> l2 = stackalloc char[44];
+        for (int i = 0; i < 44; i++)
+        {
+            char c1 = line1[i];
+            char c2 = line2[i];
+            if (c1 >= 'a' && c1 <= 'z') c1 = (char)(c1 - 32);
+            if (c2 >= 'a' && c2 <= 'z') c2 = (char)(c2 - 32);
+            if (!IsMrzChar(c1) || !IsMrzChar(c2))
+            {
+                result = new ValidationResult<IcaoMrzValue>(false, default, ValidationError.Charset);
+                return false;
+            }
+            l1[i] = c1;
+            l2[i] = c2;
+        }
+        if (!Mrz.Validate(l2[..9], l2[9]) ||
+            !Mrz.Validate(l2.Slice(13, 6), l2[19]) ||
+            !Mrz.Validate(l2.Slice(21, 6), l2[27]) ||
+            !Mrz.Validate(l2.Slice(28, 14), l2[42]))
+        {
+            result = new ValidationResult<IcaoMrzValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        Span<char> comp = stackalloc char[39];
+        l2[..10].CopyTo(comp); // passport number + check
+        l2.Slice(13, 7).CopyTo(comp[10..]); // birth + check
+        l2.Slice(21, 7).CopyTo(comp[17..]); // expiry + check
+        l2.Slice(28, 15).CopyTo(comp[24..]); // personal number + check
+        if (!Mrz.Validate(comp, l2[43]))
+        {
+            result = new ValidationResult<IcaoMrzValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<IcaoMrzValue>(true, new IcaoMrzValue(string.Concat(new string(l1), "\n", new string(l2))), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a sample TD3 MRZ into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a sample TD3 MRZ using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 89)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        Span<char> line1 = destination[..44];
+        Span<char> line2 = destination.Slice(45, 44);
+        line1[0] = 'P';
+        line1[1] = '<';
+        var cc = _countryCodes[rng.Next(_countryCodes.Length)];
+        line1[2] = cc[0];
+        line1[3] = cc[1];
+        line1[4] = cc[2];
+        Fill(line1[5..], '<');
+        Span<char> passport = stackalloc char[9];
+        for (int i = 0; i < 9; i++) passport[i] = (char)('0' + rng.Next(10));
+        passport.CopyTo(line2);
+        line2[9] = (char)('0' + Mrz.Compute(passport));
+        line2[10] = cc[0]; line2[11] = cc[1]; line2[12] = cc[2];
+        Span<char> birth = stackalloc char[6];
+        RandomDate(rng, 1950, 2005, birth);
+        birth.CopyTo(line2.Slice(13, 6));
+        line2[19] = (char)('0' + Mrz.Compute(birth));
+        line2[20] = rng.Next(2) == 0 ? 'M' : 'F';
+        Span<char> exp = stackalloc char[6];
+        RandomDate(rng, 2025, 2035, exp);
+        exp.CopyTo(line2.Slice(21, 6));
+        line2[27] = (char)('0' + Mrz.Compute(exp));
+        Fill(line2.Slice(28, 14), '<');
+        line2[42] = (char)('0' + Mrz.Compute(line2.Slice(28, 14)));
+        Span<char> comp = stackalloc char[39];
+        line2[..10].CopyTo(comp);
+        line2.Slice(13, 7).CopyTo(comp[10..]);
+        line2.Slice(21, 7).CopyTo(comp[17..]);
+        line2.Slice(28, 15).CopyTo(comp[24..]);
+        line2[43] = (char)('0' + Mrz.Compute(comp));
+        destination[44] = '\n';
+        written = 89;
+        return true;
+    }
+
+    private static bool IsMrzChar(char c)
+        => (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '<';
+
+    private static void Fill(Span<char> span, char value)
+    {
+        for (int i = 0; i < span.Length; i++) span[i] = value;
+    }
+
+    private static void RandomDate(Random rng, int startYear, int endYear, Span<char> dest)
+    {
+        int year = rng.Next(startYear, endYear + 1);
+        int month = rng.Next(1, 13);
+        int day = rng.Next(1, 28);
+        dest[0] = (char)('0' + (year / 10_00) % 10);
+        dest[1] = (char)('0' + (year / 100) % 10);
+        dest[2] = (char)('0' + (month / 10));
+        dest[3] = (char)('0' + (month % 10));
+        dest[4] = (char)('0' + (day / 10));
+        dest[5] = (char)('0' + (day % 10));
+    }
+
+    private static readonly string[] _countryCodes = { "USA", "GBR", "FRA", "DEU", "CAN", "AUS" };
+}
+

--- a/src/Veritas/Logistics/Gdti.cs
+++ b/src/Veritas/Logistics/Gdti.cs
@@ -1,0 +1,66 @@
+using System;
+using Veritas.Algorithms;
+using Veritas;
+
+namespace Veritas.Logistics;
+
+/// <summary>GS1 Global Document Type Identifier (GDTI).</summary>
+public readonly struct GdtiValue
+{
+    /// <summary>The normalized GDTI string.</summary>
+    public string Value { get; }
+    public GdtiValue(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for GDTI codes.</summary>
+public static class Gdti
+{
+    /// <summary>Validates the supplied GDTI.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<GdtiValue> result)
+    {
+        Span<char> digits = stackalloc char[14];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (ch < '0' || ch > '9' || len >= 14)
+            {
+                result = new ValidationResult<GdtiValue>(false, default, ValidationError.Charset);
+                return false;
+            }
+            digits[len++] = ch;
+        }
+        if (len != 14)
+        {
+            result = new ValidationResult<GdtiValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        if (!Gs1.Validate(digits))
+        {
+            result = new ValidationResult<GdtiValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<GdtiValue>(true, new GdtiValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a valid GDTI into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a valid GDTI using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 14)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < 13; i++) destination[i] = (char)('0' + rng.Next(10));
+        destination[13] = (char)('0' + Gs1.ComputeCheckDigit(destination[..13]));
+        written = 14;
+        return true;
+    }
+}
+

--- a/src/Veritas/Logistics/Giai.cs
+++ b/src/Veritas/Logistics/Giai.cs
@@ -1,0 +1,66 @@
+using System;
+using Veritas;
+
+namespace Veritas.Logistics;
+
+/// <summary>GS1 Global Individual Asset Identifier (GIAI).</summary>
+public readonly struct GiaiValue
+{
+    /// <summary>The normalized GIAI string.</summary>
+    public string Value { get; }
+    public GiaiValue(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for GIAI codes.</summary>
+public static class Giai
+{
+    /// <summary>Validates the supplied GIAI.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<GiaiValue> result)
+    {
+        Span<char> buffer = stackalloc char[30];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            char c = ch;
+            if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+            if (!((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z')) || len >= 30)
+            {
+                result = new ValidationResult<GiaiValue>(false, default, ValidationError.Charset);
+                return false;
+            }
+            buffer[len++] = c;
+        }
+        if (len == 0 || len > 30)
+        {
+            result = new ValidationResult<GiaiValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        result = new ValidationResult<GiaiValue>(true, new GiaiValue(new string(buffer[..len])), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a random GIAI into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a random GIAI using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        int length = 12;
+        if (destination.Length < length)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        for (int i = 0; i < length; i++)
+        {
+            int v = rng.Next(36);
+            destination[i] = (char)(v < 10 ? '0' + v : 'A' + v - 10);
+        }
+        written = length;
+        return true;
+    }
+}
+

--- a/src/Veritas/Logistics/UpuS10.cs
+++ b/src/Veritas/Logistics/UpuS10.cs
@@ -1,0 +1,93 @@
+using System;
+using Veritas;
+
+namespace Veritas.Logistics;
+
+/// <summary>UPU S10 international postal tracking number.</summary>
+public readonly struct UpuS10Value
+{
+    /// <summary>The normalized S10 string.</summary>
+    public string Value { get; }
+    public UpuS10Value(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for UPU S10 tracking numbers.</summary>
+public static class UpuS10
+{
+    /// <summary>Validates the supplied S10 tracking number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<UpuS10Value> result)
+    {
+        Span<char> buf = stackalloc char[13];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (len >= 13) { result = new ValidationResult<UpuS10Value>(false, default, ValidationError.Length); return false; }
+            char c = ch;
+            if (len < 2 || len >= 11)
+            {
+                if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+                if (c < 'A' || c > 'Z') { result = new ValidationResult<UpuS10Value>(false, default, ValidationError.Charset); return false; }
+            }
+            else
+            {
+                if (c < '0' || c > '9') { result = new ValidationResult<UpuS10Value>(false, default, ValidationError.Charset); return false; }
+            }
+            buf[len++] = c;
+        }
+        if (len != 13)
+        {
+            result = new ValidationResult<UpuS10Value>(false, default, ValidationError.Length);
+            return false;
+        }
+        int check = buf[10] - '0';
+        int expected = ComputeCheckDigit(buf.Slice(2, 8));
+        if (check != expected)
+        {
+            result = new ValidationResult<UpuS10Value>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<UpuS10Value>(true, new UpuS10Value(new string(buf)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a valid S10 tracking number into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a valid S10 tracking number using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 13)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        var svc = _serviceCodes[rng.Next(_serviceCodes.Length)];
+        destination[0] = svc[0];
+        destination[1] = svc[1];
+        for (int i = 0; i < 8; i++) destination[2 + i] = (char)('0' + rng.Next(10));
+        destination[10] = (char)('0' + ComputeCheckDigit(destination.Slice(2, 8)));
+        var cc = _countryCodes[rng.Next(_countryCodes.Length)];
+        destination[11] = cc[0];
+        destination[12] = cc[1];
+        written = 13;
+        return true;
+    }
+
+    private static int ComputeCheckDigit(ReadOnlySpan<char> digits)
+    {
+        int[] weights = { 8, 6, 4, 2, 3, 5, 9, 7 };
+        int sum = 0;
+        for (int i = 0; i < 8; i++) sum += (digits[i] - '0') * weights[i];
+        int mod = 11 - (sum % 11);
+        if (mod == 10) return 0;
+        if (mod == 11) return 5;
+        return mod;
+    }
+
+    private static readonly string[] _serviceCodes = { "RA", "RB", "RC", "RR", "CP", "LX" };
+    private static readonly string[] _countryCodes = { "US", "GB", "DE", "FR", "CN", "JP", "BR", "IN" };
+}
+

--- a/src/Veritas/Tax/Eori.cs
+++ b/src/Veritas/Tax/Eori.cs
@@ -1,0 +1,78 @@
+using System;
+using Veritas;
+
+namespace Veritas.Tax;
+
+/// <summary>Represents a validated Economic Operator Registration and Identification (EORI) number.</summary>
+/// <example>Eori.TryValidate("DE123456789012345", out var value);</example>
+public readonly struct EoriValue
+{
+    /// <summary>The normalized EORI string.</summary>
+    public string Value { get; }
+    public EoriValue(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for EORI numbers.</summary>
+public static class Eori
+{
+    /// <summary>Validates the supplied EORI string.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<EoriValue> result)
+    {
+        Span<char> buffer = stackalloc char[17];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            char c = ch;
+            if (len < 2)
+            {
+                if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+                if (c < 'A' || c > 'Z') { result = new ValidationResult<EoriValue>(false, default, ValidationError.Charset); return false; }
+                buffer[len++] = c;
+            }
+            else
+            {
+                if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+                if (!((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'))) { result = new ValidationResult<EoriValue>(false, default, ValidationError.Charset); return false; }
+                if (len >= buffer.Length) { result = new ValidationResult<EoriValue>(false, default, ValidationError.Length); return false; }
+                buffer[len++] = c;
+            }
+        }
+        if (len < 3 || len > 17)
+        {
+            result = new ValidationResult<EoriValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        result = new ValidationResult<EoriValue>(true, new EoriValue(new string(buffer[..len])), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a valid EORI into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a valid EORI using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        var cc = _countryCodes[rng.Next(_countryCodes.Length)];
+        int tailLen = 1 + rng.Next(15); // 1..15
+        int total = 2 + tailLen;
+        if (destination.Length < total)
+        {
+            written = 0;
+            return false;
+        }
+        destination[0] = cc[0];
+        destination[1] = cc[1];
+        for (int i = 0; i < tailLen; i++)
+            destination[2 + i] = (char)('0' + rng.Next(10));
+        written = total;
+        return true;
+    }
+
+    private static readonly string[] _countryCodes = new[]
+    {
+        "AT","BE","BG","CY","CZ","DE","DK","EE","ES","FI","FR","GR","HR","HU","IE","IT","LT","LU","LV","MT","NL","PL","PT","RO","SE","SI","SK","GB"
+    };
+}

--- a/src/Veritas/Telecom/Imsi.cs
+++ b/src/Veritas/Telecom/Imsi.cs
@@ -1,0 +1,91 @@
+using System;
+using Veritas;
+
+namespace Veritas.Telecom;
+
+/// <summary>Represents a validated International Mobile Subscriber Identity (IMSI).</summary>
+public readonly struct ImsiValue
+{
+    /// <summary>Gets the normalized IMSI string.</summary>
+    public string Value { get; }
+
+    /// <summary>Initializes a new instance of the <see cref="ImsiValue"/> struct.</summary>
+    /// <param name="value">The code string.</param>
+    public ImsiValue(string value) => Value = value;
+}
+
+/// <summary>Provides validation and generation for IMSI numbers.</summary>
+public static class Imsi
+{
+    /// <summary>Attempts to validate the supplied input as an IMSI.</summary>
+    /// <param name="input">Candidate code to validate.</param>
+    /// <param name="result">The validation outcome including the parsed value when valid.</param>
+    /// <returns><c>true</c> if validation succeeded; otherwise, <c>false</c>.</returns>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<ImsiValue> result)
+    {
+        Span<char> digits = stackalloc char[15];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-')
+                continue;
+            if (ch < '0' || ch > '9')
+            {
+                result = new ValidationResult<ImsiValue>(false, default, ValidationError.Charset);
+                return false;
+            }
+            if (len >= 15)
+            {
+                result = new ValidationResult<ImsiValue>(false, default, ValidationError.Length);
+                return false;
+            }
+            digits[len++] = ch;
+        }
+        if (len != 15)
+        {
+            result = new ValidationResult<ImsiValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        result = new ValidationResult<ImsiValue>(true, new ImsiValue(new string(digits)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Attempts to generate a random IMSI into the provided buffer.</summary>
+    /// <param name="destination">Buffer that receives the generated code.</param>
+    /// <param name="written">When the method returns, contains the number of characters produced.</param>
+    /// <returns><c>true</c> if generation succeeded; otherwise, <c>false</c>.</returns>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Attempts to generate a random IMSI using the supplied options.</summary>
+    /// <param name="options">Options controlling generation.</param>
+    /// <param name="destination">Buffer that receives the generated code.</param>
+    /// <param name="written">When the method returns, contains the number of characters produced.</param>
+    /// <returns><c>true</c> if generation succeeded; otherwise, <c>false</c>.</returns>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 15)
+        {
+            written = 0;
+            return false;
+        }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        var (mcc, mncs) = _samples[rng.Next(_samples.Length)];
+        mcc.AsSpan().CopyTo(destination);
+        var mnc = mncs[rng.Next(mncs.Length)];
+        mnc.AsSpan().CopyTo(destination.Slice(3));
+        int pos = 3 + mnc.Length;
+        for (int i = pos; i < 15; i++)
+            destination[i] = (char)('0' + rng.Next(10));
+        written = 15;
+        return true;
+    }
+
+    private static readonly (string Mcc, string[] Mncs)[] _samples = new[]
+    {
+        ("310", new[] { "260", "410" }), // United States
+        ("262", new[] { "01", "02" }),   // Germany
+        ("234", new[] { "10", "15" })    // United Kingdom
+    };
+}
+

--- a/test/Veritas.Tests/Finance/ES/CccTests.cs
+++ b/test/Veritas.Tests/Finance/ES/CccTests.cs
@@ -1,0 +1,26 @@
+using Veritas.Finance.ES;
+
+namespace Veritas.Tests.Finance.ES;
+
+public class CccTests
+{
+    [Fact]
+    public void Validate_Works()
+    {
+        Span<char> dest = stackalloc char[20];
+        Assert.True(Ccc.TryGenerate(dest, out var written));
+        var s = new string(dest[..written]);
+        Assert.True(Ccc.TryValidate(s, out var result));
+        dest[8] = dest[8] == '0' ? '1' : '0';
+        Assert.False(Ccc.TryValidate(new string(dest[..written]), out _));
+    }
+
+    [Fact]
+    public void Generate_ProducesValid()
+    {
+        Span<char> dest = stackalloc char[20];
+        Assert.True(Ccc.TryGenerate(dest, out var written));
+        Assert.True(Ccc.TryValidate(new string(dest[..written]), out _));
+    }
+}
+

--- a/test/Veritas.Tests/Finance/FR/RibTests.cs
+++ b/test/Veritas.Tests/Finance/FR/RibTests.cs
@@ -1,0 +1,26 @@
+using Veritas.Finance.FR;
+
+namespace Veritas.Tests.Finance.FR;
+
+public class RibTests
+{
+    [Theory]
+    [InlineData("20041 01005 0500013M026 06", true)]
+    [InlineData("20041010050500013M02606", true)]
+    [InlineData("20041010050500013M02607", false)]
+    public void Validate_Works(string input, bool expected)
+    {
+        var ok = Rib.TryValidate(input, out var result);
+        Assert.Equal(expected, ok);
+        Assert.Equal(expected, result.IsValid);
+    }
+
+    [Fact]
+    public void Generate_ProducesValid()
+    {
+        Span<char> dest = stackalloc char[23];
+        Assert.True(Rib.TryGenerate(dest, out var written));
+        Assert.True(Rib.TryValidate(new string(dest[..written]), out _));
+    }
+}
+

--- a/test/Veritas.Tests/Finance/SepaCreditorIdentifierTests.cs
+++ b/test/Veritas.Tests/Finance/SepaCreditorIdentifierTests.cs
@@ -1,0 +1,25 @@
+using System;
+using Veritas.Finance;
+using Xunit;
+using Shouldly;
+
+public class SepaCreditorIdentifierTests
+{
+    [Theory]
+    [InlineData("DE74ZZZ09999999999", true)]
+    [InlineData("DE75ZZZ09999999999", false)]
+    public void Validate_Works(string input, bool expected)
+    {
+        SepaCreditorIdentifier.TryValidate(input, out var result).ShouldBe(expected);
+        result.IsValid.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GenerateProducesValid()
+    {
+        Span<char> buffer = stackalloc char[35];
+        SepaCreditorIdentifier.TryGenerate(buffer, out var written).ShouldBeTrue();
+        SepaCreditorIdentifier.TryValidate(buffer[..written], out var result).ShouldBeTrue();
+        result.IsValid.ShouldBeTrue();
+    }
+}

--- a/test/Veritas.Tests/Healthcare/DeaNumberTests.cs
+++ b/test/Veritas.Tests/Healthcare/DeaNumberTests.cs
@@ -1,0 +1,25 @@
+using Veritas.Healthcare;
+using Xunit;
+using Shouldly;
+
+public class DeaNumberTests
+{
+    [Theory]
+    [InlineData("AB1234563", true)]
+    [InlineData("AB1234560", false)]
+    [InlineData("A91234563", true)]
+    public void Validate(string input, bool expected)
+    {
+        DeaNumber.TryValidate(input, out var r).ShouldBe(expected);
+        r.IsValid.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GenerateProducesValid()
+    {
+        Span<char> buffer = stackalloc char[9];
+        DeaNumber.TryGenerate(buffer, out var written).ShouldBeTrue();
+        DeaNumber.TryValidate(buffer[..written], out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+}

--- a/test/Veritas.Tests/Healthcare/NpiTests.cs
+++ b/test/Veritas.Tests/Healthcare/NpiTests.cs
@@ -1,0 +1,24 @@
+using Veritas.Healthcare;
+using Xunit;
+using Shouldly;
+
+public class NpiTests
+{
+    [Theory]
+    [InlineData("1234567893", true)]
+    [InlineData("1234567890", false)]
+    public void Validate(string input, bool expected)
+    {
+        Npi.TryValidate(input, out var r).ShouldBe(expected);
+        r.IsValid.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GenerateProducesValid()
+    {
+        Span<char> buffer = stackalloc char[10];
+        Npi.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Npi.TryValidate(buffer[..written], out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+}

--- a/test/Veritas.Tests/Identity/IcaoMrzTests.cs
+++ b/test/Veritas.Tests/Identity/IcaoMrzTests.cs
@@ -1,0 +1,27 @@
+using Veritas.Identity;
+
+namespace Veritas.Tests.Identity;
+
+public class IcaoMrzTests
+{
+    private const string Sample = "P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\nL898902C36UTO7408122F1204159ZE184226B<<<<<10";
+
+    [Theory]
+    [InlineData(Sample, true)]
+    [InlineData("P<UTOERIKSSON<<ANNA<MARIA<<<<<<<<<<<<<<<<<<<\nL898902C36UTO7408122F1204159ZE184226B<<<<<11", false)]
+    public void Validate_Works(string input, bool expected)
+    {
+        var ok = IcaoMrz.TryValidate(input, out var result);
+        Assert.Equal(expected, ok);
+        Assert.Equal(expected, result.IsValid);
+    }
+
+    [Fact]
+    public void Generate_ProducesValid()
+    {
+        Span<char> dest = stackalloc char[89];
+        Assert.True(IcaoMrz.TryGenerate(dest, out var written));
+        Assert.True(IcaoMrz.TryValidate(new string(dest[..written]), out _));
+    }
+}
+

--- a/test/Veritas.Tests/Logistics/GdtiTests.cs
+++ b/test/Veritas.Tests/Logistics/GdtiTests.cs
@@ -1,0 +1,25 @@
+using Veritas.Logistics;
+
+namespace Veritas.Tests.Logistics;
+
+public class GdtiTests
+{
+    [Theory]
+    [InlineData("12345678901231", true)]
+    [InlineData("12345678901232", false)]
+    public void Validate_Works(string input, bool expected)
+    {
+        var ok = Gdti.TryValidate(input, out var result);
+        Assert.Equal(expected, ok);
+        Assert.Equal(expected, result.IsValid);
+    }
+
+    [Fact]
+    public void Generate_ProducesValid()
+    {
+        Span<char> dest = stackalloc char[14];
+        Assert.True(Gdti.TryGenerate(dest, out var written));
+        Assert.True(Gdti.TryValidate(new string(dest[..written]), out _));
+    }
+}
+

--- a/test/Veritas.Tests/Logistics/GiaiTests.cs
+++ b/test/Veritas.Tests/Logistics/GiaiTests.cs
@@ -1,0 +1,26 @@
+using Veritas.Logistics;
+
+namespace Veritas.Tests.Logistics;
+
+public class GiaiTests
+{
+    [Theory]
+    [InlineData("ABC123XYZ789", true)]
+    [InlineData("abc123", true)]
+    [InlineData("!123", false)]
+    public void Validate_Works(string input, bool expected)
+    {
+        var ok = Giai.TryValidate(input, out var result);
+        Assert.Equal(expected, ok);
+        Assert.Equal(expected, result.IsValid);
+    }
+
+    [Fact]
+    public void Generate_ProducesValid()
+    {
+        Span<char> dest = stackalloc char[12];
+        Assert.True(Giai.TryGenerate(dest, out var written));
+        Assert.True(Giai.TryValidate(new string(dest[..written]), out _));
+    }
+}
+

--- a/test/Veritas.Tests/Logistics/UpuS10Tests.cs
+++ b/test/Veritas.Tests/Logistics/UpuS10Tests.cs
@@ -1,0 +1,26 @@
+using Veritas.Logistics;
+
+namespace Veritas.Tests.Logistics;
+
+public class UpuS10Tests
+{
+    [Theory]
+    [InlineData("RA123456785GB", true)]
+    [InlineData("RA123456785US", true)]
+    [InlineData("RA123456784GB", false)]
+    public void Validate_Works(string input, bool expected)
+    {
+        var ok = UpuS10.TryValidate(input, out var result);
+        Assert.Equal(expected, ok);
+        Assert.Equal(expected, result.IsValid);
+    }
+
+    [Fact]
+    public void Generate_ProducesValid()
+    {
+        Span<char> dest = stackalloc char[13];
+        Assert.True(UpuS10.TryGenerate(dest, out var written));
+        Assert.True(UpuS10.TryValidate(new string(dest[..written]), out _));
+    }
+}
+

--- a/test/Veritas.Tests/Tax/EoriTests.cs
+++ b/test/Veritas.Tests/Tax/EoriTests.cs
@@ -1,0 +1,26 @@
+using Veritas.Tax;
+using Xunit;
+using Shouldly;
+
+public class EoriTests
+{
+    [Theory]
+    [InlineData("DE123456789012345", true)]
+    [InlineData("fr12345678901234", true)]
+    [InlineData("F123", false)]
+    [InlineData("DE1234567890123456", false)]
+    public void Validate(string input, bool expected)
+    {
+        Eori.TryValidate(input, out var r).ShouldBe(expected);
+        r.IsValid.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GenerateProducesValid()
+    {
+        Span<char> buffer = stackalloc char[17];
+        Eori.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Eori.TryValidate(buffer[..written], out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+}

--- a/test/Veritas.Tests/Telecom/ImsiTests.cs
+++ b/test/Veritas.Tests/Telecom/ImsiTests.cs
@@ -1,0 +1,27 @@
+using System;
+using Veritas.Telecom;
+using Xunit;
+using Shouldly;
+
+public class ImsiTests
+{
+    [Theory]
+    [InlineData("310260123456789", true)]
+    [InlineData("31026A123456789", false)]
+    [InlineData("12345678901234", false)]
+    public void Validate(string input, bool expected)
+    {
+        Imsi.TryValidate(input, out var r).ShouldBe(expected);
+        r.IsValid.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void GenerateProducesValid()
+    {
+        Span<char> buffer = stackalloc char[15];
+        Imsi.TryGenerate(buffer, out var written).ShouldBeTrue();
+        Imsi.TryValidate(buffer[..written], out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement SEPA Creditor Identifier
- implement French RIB key
- implement Spanish CCC bank account
- add UPU S10 tracking number
- add GS1 GDTI and GIAI
- add ICAO MRZ passport lines
- implement DEA number
- implement NPI
- add EU/GB EORI
- add IMSI
- document new identifier support
- add unit tests for each identifier
- document definition of done and coding style guidance in AGENTS

## Testing
- `dotnet format --verify-no-changes -v diag`
- `dotnet test`
- `docfx docfx/docfx.json`


------
https://chatgpt.com/codex/tasks/task_e_68c5beae019c832b9a33f8a9fc0cd8e9