### PR TITLE
Add intellectual property and legal identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,18 @@ dotnet add package Veritas --version 1.0.3
 - IPv4 structural validation
 - IPv6 structural validation
 
-### IP
+### Intellectual Property
 - Singapore IPOS application number validation and generation
+- ISWC validation and generation
+- Patent application number (WIPO ST.13) validation and generation
+- Patent publication number (WIPO ST.16) validation and generation
+- Trademark registration number validation and generation
+- Copyright registration number validation and generation
+
+### Legal
+- European Case Law Identifier (ECLI) validation and generation
+- U.S. court case number validation and generation
+- European Patent Office publication identifier validation and generation
 
 ### Education & Media
 - ISBN-10 validation and generation

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -219,11 +219,24 @@ foreach (var s in Bulk.GenerateMany((dst, rng) => {
 | IPv4 | Global | structural check | <xref:Veritas.Telecom.Ipv4> |
 | IPv6 | Global | structural check | <xref:Veritas.Telecom.Ipv6> |
 
-### IP
+### Intellectual Property
 
 | Identifier | Country/Region | Validation & Generation | Docs |
 |------------|----------------|-------------------------|------|
-| IPOS Application Number | Singapore | Damm checksum; test generation | <xref:Veritas.IP.Singapore.IpApplicationNumber> |
+| IPOS Application Number | Singapore | Damm checksum; test generation | <xref:Veritas.IntellectualProperty.SG.IpApplicationNumber> |
+| ISWC | International | mod 10 checksum; generation | <xref:Veritas.IntellectualProperty.Iswc> |
+| Patent Application Number | International | structural check; generation | <xref:Veritas.IntellectualProperty.PatentApplicationNumber> |
+| Patent Publication Number | International | structural check; generation | <xref:Veritas.IntellectualProperty.PatentPublicationNumber> |
+| Trademark Registration Number | International | structural check; generation | <xref:Veritas.IntellectualProperty.TrademarkRegistrationNumber> |
+| Copyright Registration Number | International | structural check; generation | <xref:Veritas.IntellectualProperty.CopyrightRegistrationNumber> |
+
+### Legal
+
+| Identifier | Country/Region | Validation & Generation | Docs |
+|------------|----------------|-------------------------|------|
+| European Case Law Identifier (ECLI) | EU | structural check; generation | <xref:Veritas.Legal.EU.Ecli> |
+| Court Case Number | US | structural check; generation | <xref:Veritas.Legal.US.CourtCaseNumber> |
+| European Patent Office Publication ID | EU | structural check; generation | <xref:Veritas.Legal.EU.EuropeanPatentOfficePublicationId> |
 
 ### Education & Media
 

--- a/src/Veritas/IntellectualProperty/CopyrightRegistrationNumber.cs
+++ b/src/Veritas/IntellectualProperty/CopyrightRegistrationNumber.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace Veritas.IntellectualProperty;
+
+/// <summary>Validation and generation for copyright registration numbers.</summary>
+/// <example>
+/// <code language="csharp">
+/// Span&lt;char&gt; dst = stackalloc char[12];
+/// CopyrightRegistrationNumber.TryGenerate(default, dst, out _);
+/// </code>
+/// </example>
+public static class CopyrightRegistrationNumber
+{
+    private static readonly string[] _prefixes = { "TX", "VA", "SR" };
+
+    /// <summary>Validates a copyright registration number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<CopyrightRegistrationNumberValue> result)
+    {
+        Span<char> buf = stackalloc char[12];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (len >= 12) { result = new ValidationResult<CopyrightRegistrationNumberValue>(false, default, ValidationError.Length); return false; }
+            char c = ch;
+            if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+            if (len < 2)
+            {
+                if (c < 'A' || c > 'Z') { result = new ValidationResult<CopyrightRegistrationNumberValue>(false, default, ValidationError.Charset); return false; }
+            }
+            else
+            {
+                if (c < '0' || c > '9') { result = new ValidationResult<CopyrightRegistrationNumberValue>(false, default, ValidationError.Charset); return false; }
+            }
+            buf[len++] = c;
+        }
+        if (len != 12)
+        {
+            result = new ValidationResult<CopyrightRegistrationNumberValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        result = new ValidationResult<CopyrightRegistrationNumberValue>(true, new CopyrightRegistrationNumberValue(new string(buf)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a copyright registration number into the destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a copyright registration number using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 12) { written = 0; return false; }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        var prefix = _prefixes[rng.Next(_prefixes.Length)];
+        destination[0] = prefix[0];
+        destination[1] = prefix[1];
+        int year = rng.Next(1978, DateTime.UtcNow.Year + 1);
+        destination[2] = (char)('0' + (year / 1000 % 10));
+        destination[3] = (char)('0' + (year / 100 % 10));
+        destination[4] = (char)('0' + (year / 10 % 10));
+        destination[5] = (char)('0' + (year % 10));
+        int serial = rng.Next(0, 1_000_000);
+        for (int i = 0; i < 6; i++)
+        {
+            destination[11 - i] = (char)('0' + (serial % 10));
+            serial /= 10;
+        }
+        written = 12;
+        return true;
+    }
+}

--- a/src/Veritas/IntellectualProperty/CopyrightRegistrationNumberValue.cs
+++ b/src/Veritas/IntellectualProperty/CopyrightRegistrationNumberValue.cs
@@ -1,0 +1,10 @@
+namespace Veritas.IntellectualProperty;
+
+/// <summary>Represents a validated copyright registration number.</summary>
+public readonly struct CopyrightRegistrationNumberValue
+{
+    /// <summary>The normalized registration number.</summary>
+    public string Value { get; }
+    public CopyrightRegistrationNumberValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/src/Veritas/IntellectualProperty/Iswc.cs
+++ b/src/Veritas/IntellectualProperty/Iswc.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace Veritas.IntellectualProperty;
+
+/// <summary>Validation and generation for International Standard Musical Work Codes (ISWC).</summary>
+/// <example>
+/// <code language="csharp">
+/// Span&lt;char&gt; dst = stackalloc char[11];
+/// Iswc.TryGenerate(default, dst, out _);
+/// </code>
+/// </example>
+public static class Iswc
+{
+    /// <summary>Validates the supplied ISWC.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<IswcValue> result)
+    {
+        Span<char> buf = stackalloc char[11];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-' || ch == '.') continue;
+            if (len >= 11) { result = new ValidationResult<IswcValue>(false, default, ValidationError.Length); return false; }
+            char c = ch;
+            if (len == 0)
+            {
+                if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+                if (c != 'T') { result = new ValidationResult<IswcValue>(false, default, ValidationError.Format); return false; }
+            }
+            else
+            {
+                if (c < '0' || c > '9') { result = new ValidationResult<IswcValue>(false, default, ValidationError.Charset); return false; }
+            }
+            buf[len++] = c;
+        }
+        if (len != 11)
+        {
+            result = new ValidationResult<IswcValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        int sum = 1;
+        for (int i = 1; i <= 9; i++) sum += (buf[i] - '0') * i;
+        int check = (10 - (sum % 10)) % 10;
+        if (buf[10] - '0' != check)
+        {
+            result = new ValidationResult<IswcValue>(false, default, ValidationError.Checksum);
+            return false;
+        }
+        result = new ValidationResult<IswcValue>(true, new IswcValue(new string(buf)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a valid ISWC into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a valid ISWC using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 11) { written = 0; return false; }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        destination[0] = 'T';
+        for (int i = 1; i <= 9; i++) destination[i] = (char)('0' + rng.Next(10));
+        int sum = 1;
+        for (int i = 1; i <= 9; i++) sum += (destination[i] - '0') * i;
+        destination[10] = (char)('0' + ((10 - (sum % 10)) % 10));
+        written = 11;
+        return true;
+    }
+}

--- a/src/Veritas/IntellectualProperty/IswcValue.cs
+++ b/src/Veritas/IntellectualProperty/IswcValue.cs
@@ -1,0 +1,10 @@
+namespace Veritas.IntellectualProperty;
+
+/// <summary>Represents a validated International Standard Musical Work Code (ISWC).</summary>
+public readonly struct IswcValue
+{
+    /// <summary>The normalized ISWC string.</summary>
+    public string Value { get; }
+    public IswcValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/src/Veritas/IntellectualProperty/PatentApplicationNumber.cs
+++ b/src/Veritas/IntellectualProperty/PatentApplicationNumber.cs
@@ -1,0 +1,71 @@
+using System;
+
+namespace Veritas.IntellectualProperty;
+
+/// <summary>Validation and generation for WIPO ST.13 patent application numbers.</summary>
+/// <example>
+/// <code language="csharp">
+/// Span&lt;char&gt; dst = stackalloc char[10];
+/// PatentApplicationNumber.TryGenerate(default, dst, out _);
+/// </code>
+/// </example>
+public static class PatentApplicationNumber
+{
+    private static readonly string[] _countryCodes = { "US", "GB", "JP", "DE", "FR" };
+
+    /// <summary>Validates the supplied patent application number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<PatentApplicationNumberValue> result)
+    {
+        Span<char> buf = stackalloc char[10];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (len >= 10) { result = new ValidationResult<PatentApplicationNumberValue>(false, default, ValidationError.Length); return false; }
+            char c = ch;
+            if (len < 2)
+            {
+                if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+                if (c < 'A' || c > 'Z') { result = new ValidationResult<PatentApplicationNumberValue>(false, default, ValidationError.Charset); return false; }
+            }
+            else
+            {
+                if (c < '0' || c > '9') { result = new ValidationResult<PatentApplicationNumberValue>(false, default, ValidationError.Charset); return false; }
+            }
+            buf[len++] = c;
+        }
+        if (len < 5 || len > 10)
+        {
+            result = new ValidationResult<PatentApplicationNumberValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        if (len > 4 && len - 4 > 6) { result = new ValidationResult<PatentApplicationNumberValue>(false, default, ValidationError.Length); return false; }
+        result = new ValidationResult<PatentApplicationNumberValue>(true, new PatentApplicationNumberValue(new string(buf[..len])), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a patent application number into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a patent application number using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 10) { written = 0; return false; }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        var cc = _countryCodes[rng.Next(_countryCodes.Length)];
+        destination[0] = cc[0];
+        destination[1] = cc[1];
+        int year = rng.Next(0, 100);
+        destination[2] = (char)('0' + year / 10);
+        destination[3] = (char)('0' + year % 10);
+        int serial = rng.Next(0, 1_000_000);
+        for (int i = 0; i < 6; i++)
+        {
+            destination[9 - i] = (char)('0' + (serial % 10));
+            serial /= 10;
+        }
+        written = 10;
+        return true;
+    }
+}

--- a/src/Veritas/IntellectualProperty/PatentApplicationNumberValue.cs
+++ b/src/Veritas/IntellectualProperty/PatentApplicationNumberValue.cs
@@ -1,0 +1,10 @@
+namespace Veritas.IntellectualProperty;
+
+/// <summary>Represents a validated WIPO ST.13 patent application number.</summary>
+public readonly struct PatentApplicationNumberValue
+{
+    /// <summary>The normalized application number.</summary>
+    public string Value { get; }
+    public PatentApplicationNumberValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/src/Veritas/IntellectualProperty/PatentPublicationNumber.cs
+++ b/src/Veritas/IntellectualProperty/PatentPublicationNumber.cs
@@ -1,0 +1,80 @@
+using System;
+
+namespace Veritas.IntellectualProperty;
+
+/// <summary>Validation and generation for WIPO ST.16 patent publication numbers.</summary>
+/// <example>
+/// <code language="csharp">
+/// Span&lt;char&gt; dst = stackalloc char[11];
+/// PatentPublicationNumber.TryGenerate(default, dst, out _);
+/// </code>
+/// </example>
+public static class PatentPublicationNumber
+{
+    private static readonly string[] _countryCodes = { "US", "EP", "WO", "JP", "DE" };
+    private static readonly string[] _kindCodes = { "A1", "B1", "A2" };
+
+    /// <summary>Validates the supplied patent publication number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<PatentPublicationNumberValue> result)
+    {
+        Span<char> buf = stackalloc char[12];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (len >= 12) { result = new ValidationResult<PatentPublicationNumberValue>(false, default, ValidationError.Length); return false; }
+            char c = ch;
+            if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+            if (len < 2)
+            {
+                if (c < 'A' || c > 'Z') { result = new ValidationResult<PatentPublicationNumberValue>(false, default, ValidationError.Charset); return false; }
+            }
+            buf[len++] = c;
+        }
+        if (len < 5)
+        {
+            result = new ValidationResult<PatentPublicationNumberValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        if (buf[len - 2] < 'A' || buf[len - 2] > 'Z' || buf[len - 1] < '0' || buf[len - 1] > '9')
+        {
+            result = new ValidationResult<PatentPublicationNumberValue>(false, default, ValidationError.Format);
+            return false;
+        }
+        for (int i = 2; i < len - 2; i++)
+        {
+            if (buf[i] < '0' || buf[i] > '9')
+            {
+                result = new ValidationResult<PatentPublicationNumberValue>(false, default, ValidationError.Charset);
+                return false;
+            }
+        }
+        result = new ValidationResult<PatentPublicationNumberValue>(true, new PatentPublicationNumberValue(new string(buf[..len])), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a patent publication number into the provided destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a patent publication number using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 11) { written = 0; return false; }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        var cc = _countryCodes[rng.Next(_countryCodes.Length)];
+        destination[0] = cc[0];
+        destination[1] = cc[1];
+        int serial = rng.Next(0, 10_000_000);
+        for (int i = 0; i < 7; i++)
+        {
+            destination[8 - i] = (char)('0' + (serial % 10));
+            serial /= 10;
+        }
+        var kind = _kindCodes[rng.Next(_kindCodes.Length)];
+        destination[9] = kind[0];
+        destination[10] = kind[1];
+        written = 11;
+        return true;
+    }
+}

--- a/src/Veritas/IntellectualProperty/PatentPublicationNumberValue.cs
+++ b/src/Veritas/IntellectualProperty/PatentPublicationNumberValue.cs
@@ -1,0 +1,10 @@
+namespace Veritas.IntellectualProperty;
+
+/// <summary>Represents a validated WIPO ST.16 patent publication number.</summary>
+public readonly struct PatentPublicationNumberValue
+{
+    /// <summary>The normalized publication number.</summary>
+    public string Value { get; }
+    public PatentPublicationNumberValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/src/Veritas/IntellectualProperty/SG/IpApplicationNumber.cs
+++ b/src/Veritas/IntellectualProperty/SG/IpApplicationNumber.cs
@@ -1,8 +1,14 @@
 using Veritas.Checksums;
 
-namespace Veritas.IP.Singapore;
+namespace Veritas.IntellectualProperty.SG;
 
 /// <summary>Validation and generation for Singapore IPOS application numbers.</summary>
+/// <example>
+/// <code language="csharp">
+/// Span&lt;char&gt; dst = stackalloc char[12];
+/// IpApplicationNumber.TryGenerate(default, dst, out _);
+/// </code>
+/// </example>
 public static class IpApplicationNumber
 {
     public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<IpApplicationNumberValue> result)

--- a/src/Veritas/IntellectualProperty/SG/IpApplicationNumberValue.cs
+++ b/src/Veritas/IntellectualProperty/SG/IpApplicationNumberValue.cs
@@ -1,4 +1,4 @@
-namespace Veritas.IP.Singapore;
+namespace Veritas.IntellectualProperty.SG;
 
 /// <summary>Represents a validated Singapore IPOS application number.</summary>
 public readonly struct IpApplicationNumberValue

--- a/src/Veritas/IntellectualProperty/TrademarkRegistrationNumber.cs
+++ b/src/Veritas/IntellectualProperty/TrademarkRegistrationNumber.cs
@@ -1,0 +1,62 @@
+using System;
+
+namespace Veritas.IntellectualProperty;
+
+/// <summary>Validation and generation for trademark registration numbers.</summary>
+/// <example>
+/// <code language="csharp">
+/// Span&lt;char&gt; dst = stackalloc char[8];
+/// TrademarkRegistrationNumber.TryGenerate(default, dst, out _);
+/// </code>
+/// </example>
+public static class TrademarkRegistrationNumber
+{
+    private static readonly string[] _prefixes = { "TM", "TR", "MR" };
+
+    /// <summary>Validates a trademark registration number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<TrademarkRegistrationNumberValue> result)
+    {
+        Span<char> buf = stackalloc char[8];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (len >= 8) { result = new ValidationResult<TrademarkRegistrationNumberValue>(false, default, ValidationError.Length); return false; }
+            char c = ch;
+            if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+            if (len < 2)
+            {
+                if (c < 'A' || c > 'Z') { result = new ValidationResult<TrademarkRegistrationNumberValue>(false, default, ValidationError.Charset); return false; }
+            }
+            else
+            {
+                if (c < '0' || c > '9') { result = new ValidationResult<TrademarkRegistrationNumberValue>(false, default, ValidationError.Charset); return false; }
+            }
+            buf[len++] = c;
+        }
+        if (len != 8)
+        {
+            result = new ValidationResult<TrademarkRegistrationNumberValue>(false, default, ValidationError.Length);
+            return false;
+        }
+        result = new ValidationResult<TrademarkRegistrationNumberValue>(true, new TrademarkRegistrationNumberValue(new string(buf)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a trademark registration number into the destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a trademark registration number using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 8) { written = 0; return false; }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        var prefix = _prefixes[rng.Next(_prefixes.Length)];
+        destination[0] = prefix[0];
+        destination[1] = prefix[1];
+        for (int i = 0; i < 6; i++) destination[2 + i] = (char)('0' + rng.Next(10));
+        written = 8;
+        return true;
+    }
+}

--- a/src/Veritas/IntellectualProperty/TrademarkRegistrationNumberValue.cs
+++ b/src/Veritas/IntellectualProperty/TrademarkRegistrationNumberValue.cs
@@ -1,0 +1,10 @@
+namespace Veritas.IntellectualProperty;
+
+/// <summary>Represents a validated trademark registration number.</summary>
+public readonly struct TrademarkRegistrationNumberValue
+{
+    /// <summary>The normalized registration number.</summary>
+    public string Value { get; }
+    public TrademarkRegistrationNumberValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/src/Veritas/Legal/EU/Ecli.cs
+++ b/src/Veritas/Legal/EU/Ecli.cs
@@ -1,0 +1,95 @@
+using System;
+
+namespace Veritas.Legal.EU;
+
+/// <summary>Validation and generation for European Case Law Identifiers (ECLI).</summary>
+/// <example>
+/// <code language="csharp">
+/// Span&lt;char&gt; dst = stackalloc char[30];
+/// Ecli.TryGenerate(default, dst, out _);
+/// </code>
+/// </example>
+public static class Ecli
+{
+    private static readonly string[] _countries = { "NL", "DE", "BE" };
+    private static readonly string[] _courts = { "HR", "GH", "PHR" };
+
+    /// <summary>Validates the supplied ECLI.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<EcliValue> result)
+    {
+        Span<char> buf = stackalloc char[32];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ') continue;
+            if (len >= 32) { result = new ValidationResult<EcliValue>(false, default, ValidationError.Length); return false; }
+            char c = ch;
+            if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+            buf[len++] = c;
+        }
+        int p1 = IndexOf(buf, len, 0);
+        int p2 = IndexOf(buf, len, p1 + 1);
+        int p3 = IndexOf(buf, len, p2 + 1);
+        int p4 = IndexOf(buf, len, p3 + 1);
+        if (p1 <= 0 || p2 <= p1 + 1 || p3 <= p2 + 1 || p4 <= p3 + 1 || p4 >= len)
+        {
+            result = new ValidationResult<EcliValue>(false, default, ValidationError.Format);
+            return false;
+        }
+        if (!buf[..p1].SequenceEqual("ECLI")) { result = new ValidationResult<EcliValue>(false, default, ValidationError.Format); return false; }
+        var cc = buf.Slice(p1 + 1, p2 - p1 - 1);
+        if (cc.Length != 2 || !IsLetters(cc)) { result = new ValidationResult<EcliValue>(false, default, ValidationError.Format); return false; }
+        var court = buf.Slice(p2 + 1, p3 - p2 - 1);
+        if (court.Length == 0 || !IsAlphaNum(court)) { result = new ValidationResult<EcliValue>(false, default, ValidationError.Format); return false; }
+        var year = buf.Slice(p3 + 1, p4 - p3 - 1);
+        if (year.Length != 4 || !IsDigits(year)) { result = new ValidationResult<EcliValue>(false, default, ValidationError.Format); return false; }
+        var id = buf.Slice(p4 + 1, len - p4 - 1);
+        if (id.Length == 0 || !IsAlphaNum(id)) { result = new ValidationResult<EcliValue>(false, default, ValidationError.Format); return false; }
+        result = new ValidationResult<EcliValue>(true, new EcliValue(new string(buf[..len])), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates an ECLI into the destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates an ECLI using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        var country = _countries[rng.Next(_countries.Length)];
+        var court = _courts[rng.Next(_courts.Length)];
+        int year = rng.Next(1990, DateTime.UtcNow.Year + 1);
+        int id = rng.Next(0, 100000);
+        var s = $"ECLI:{country}:{court}:{year}:{id:D4}";
+        if (destination.Length < s.Length) { written = 0; return false; }
+        s.AsSpan().CopyTo(destination);
+        written = s.Length;
+        return true;
+    }
+
+    private static bool IsLetters(ReadOnlySpan<char> s)
+    {
+        foreach (var c in s) if (c < 'A' || c > 'Z') return false; return true;
+    }
+    private static bool IsDigits(ReadOnlySpan<char> s)
+    {
+        foreach (var c in s) if (c < '0' || c > '9') return false; return true;
+    }
+    private static bool IsAlphaNum(ReadOnlySpan<char> s)
+    {
+        foreach (var c in s)
+        {
+            if (c >= 'A' && c <= 'Z') continue;
+            if (c >= '0' && c <= '9') continue;
+            return false;
+        }
+        return true;
+    }
+
+    private static int IndexOf(Span<char> s, int len, int start)
+    {
+        for (int i = start; i < len; i++) if (s[i] == ':') return i;
+        return -1;
+    }
+}

--- a/src/Veritas/Legal/EU/EcliValue.cs
+++ b/src/Veritas/Legal/EU/EcliValue.cs
@@ -1,0 +1,10 @@
+namespace Veritas.Legal.EU;
+
+/// <summary>Represents a validated European Case Law Identifier (ECLI).</summary>
+public readonly struct EcliValue
+{
+    /// <summary>The normalized ECLI string.</summary>
+    public string Value { get; }
+    public EcliValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/src/Veritas/Legal/EU/EuropeanPatentOfficePublicationId.cs
+++ b/src/Veritas/Legal/EU/EuropeanPatentOfficePublicationId.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace Veritas.Legal.EU;
+
+/// <summary>Validation and generation for European Patent Office publication identifiers.</summary>
+/// <example>
+/// <code language="csharp">
+/// Span&lt;char&gt; dst = stackalloc char[11];
+/// EuropeanPatentOfficePublicationId.TryGenerate(default, dst, out _);
+/// </code>
+/// </example>
+public static class EuropeanPatentOfficePublicationId
+{
+    private static readonly string[] _kindCodes = { "A1", "B1" };
+
+    /// <summary>Validates the supplied publication identifier.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<EuropeanPatentOfficePublicationIdValue> result)
+    {
+        Span<char> buf = stackalloc char[11];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (ch == ' ' || ch == '-') continue;
+            if (len >= 11) { result = new ValidationResult<EuropeanPatentOfficePublicationIdValue>(false, default, ValidationError.Length); return false; }
+            char c = ch;
+            if (c >= 'a' && c <= 'z') c = (char)(c - 32);
+            buf[len++] = c;
+        }
+        if (len != 11 || buf[0] != 'E' || buf[1] != 'P')
+        {
+            result = new ValidationResult<EuropeanPatentOfficePublicationIdValue>(false, default, ValidationError.Format);
+            return false;
+        }
+        for (int i = 2; i < 9; i++) if (buf[i] < '0' || buf[i] > '9') { result = new ValidationResult<EuropeanPatentOfficePublicationIdValue>(false, default, ValidationError.Charset); return false; }
+        if (buf[9] < 'A' || buf[9] > 'Z' || buf[10] < '0' || buf[10] > '9')
+        {
+            result = new ValidationResult<EuropeanPatentOfficePublicationIdValue>(false, default, ValidationError.Format);
+            return false;
+        }
+        result = new ValidationResult<EuropeanPatentOfficePublicationIdValue>(true, new EuropeanPatentOfficePublicationIdValue(new string(buf)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates an EPO publication identifier into the destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates an EPO publication identifier using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 11) { written = 0; return false; }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        destination[0] = 'E';
+        destination[1] = 'P';
+        int serial = rng.Next(0, 10_000_000);
+        for (int i = 0; i < 7; i++)
+        {
+            destination[8 - i] = (char)('0' + (serial % 10));
+            serial /= 10;
+        }
+        var kind = _kindCodes[rng.Next(_kindCodes.Length)];
+        destination[9] = kind[0];
+        destination[10] = kind[1];
+        written = 11;
+        return true;
+    }
+}

--- a/src/Veritas/Legal/EU/EuropeanPatentOfficePublicationIdValue.cs
+++ b/src/Veritas/Legal/EU/EuropeanPatentOfficePublicationIdValue.cs
@@ -1,0 +1,10 @@
+namespace Veritas.Legal.EU;
+
+/// <summary>Represents a validated European Patent Office publication identifier.</summary>
+public readonly struct EuropeanPatentOfficePublicationIdValue
+{
+    /// <summary>The normalized publication identifier.</summary>
+    public string Value { get; }
+    public EuropeanPatentOfficePublicationIdValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/src/Veritas/Legal/US/CourtCaseNumber.cs
+++ b/src/Veritas/Legal/US/CourtCaseNumber.cs
@@ -1,0 +1,60 @@
+using System;
+
+namespace Veritas.Legal.US;
+
+/// <summary>Validation and generation for baseline US court case numbers.</summary>
+/// <example>
+/// <code language="csharp">
+/// Span&lt;char&gt; dst = stackalloc char[11];
+/// CourtCaseNumber.TryGenerate(default, dst, out _);
+/// </code>
+/// </example>
+public static class CourtCaseNumber
+{
+    private static readonly string[] _types = { "CV", "CR", "MC" };
+
+    /// <summary>Validates the supplied court case number.</summary>
+    public static bool TryValidate(ReadOnlySpan<char> input, out ValidationResult<CourtCaseNumberValue> result)
+    {
+        Span<char> buf = stackalloc char[11];
+        int len = 0;
+        foreach (var ch in input)
+        {
+            if (len >= 11) { result = new ValidationResult<CourtCaseNumberValue>(false, default, ValidationError.Length); return false; }
+            buf[len++] = ch;
+        }
+        if (len != 11 || buf[2] != '-' || buf[8] != ' ')
+        {
+            result = new ValidationResult<CourtCaseNumberValue>(false, default, ValidationError.Format);
+            return false;
+        }
+        for (int i = 0; i < 2; i++) if (buf[i] < '0' || buf[i] > '9') { result = new ValidationResult<CourtCaseNumberValue>(false, default, ValidationError.Charset); return false; }
+        for (int i = 3; i < 8; i++) if (buf[i] < '0' || buf[i] > '9') { result = new ValidationResult<CourtCaseNumberValue>(false, default, ValidationError.Charset); return false; }
+        if (!char.IsUpper(buf[9]) || !char.IsUpper(buf[10])) { result = new ValidationResult<CourtCaseNumberValue>(false, default, ValidationError.Charset); return false; }
+        result = new ValidationResult<CourtCaseNumberValue>(true, new CourtCaseNumberValue(new string(buf)), ValidationError.None);
+        return true;
+    }
+
+    /// <summary>Generates a court case number into the destination span.</summary>
+    public static bool TryGenerate(Span<char> destination, out int written)
+        => TryGenerate(default, destination, out written);
+
+    /// <summary>Generates a court case number using the specified options.</summary>
+    public static bool TryGenerate(in GenerationOptions options, Span<char> destination, out int written)
+    {
+        if (destination.Length < 11) { written = 0; return false; }
+        var rng = options.Seed.HasValue ? new Random(options.Seed.Value) : Random.Shared;
+        int year = rng.Next(0, 100);
+        destination[0] = (char)('0' + year / 10);
+        destination[1] = (char)('0' + year % 10);
+        destination[2] = '-';
+        int seq = rng.Next(0, 100000);
+        for (int i = 0; i < 5; i++) { destination[7 - i] = (char)('0' + seq % 10); seq /= 10; }
+        destination[8] = ' ';
+        var type = _types[rng.Next(_types.Length)];
+        destination[9] = type[0];
+        destination[10] = type[1];
+        written = 11;
+        return true;
+    }
+}

--- a/src/Veritas/Legal/US/CourtCaseNumberValue.cs
+++ b/src/Veritas/Legal/US/CourtCaseNumberValue.cs
@@ -1,0 +1,10 @@
+namespace Veritas.Legal.US;
+
+/// <summary>Represents a validated court case number.</summary>
+public readonly struct CourtCaseNumberValue
+{
+    /// <summary>The normalized court case number.</summary>
+    public string Value { get; }
+    public CourtCaseNumberValue(string value) => Value = value;
+    public override string ToString() => Value;
+}

--- a/test/Veritas.Tests/IntellectualProperty/CopyrightRegistrationNumberTests.cs
+++ b/test/Veritas.Tests/IntellectualProperty/CopyrightRegistrationNumberTests.cs
@@ -1,0 +1,24 @@
+using Veritas.IntellectualProperty;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class CopyrightRegistrationNumberTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[12];
+        CopyrightRegistrationNumber.TryGenerate(new GenerationOptions { Seed = 6 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        CopyrightRegistrationNumber.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_Format()
+    {
+        CopyrightRegistrationNumber.TryValidate("TX2023ABCD12", out var r).ShouldBeFalse();
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/IntellectualProperty/IswcTests.cs
+++ b/test/Veritas.Tests/IntellectualProperty/IswcTests.cs
@@ -1,0 +1,28 @@
+using Veritas.IntellectualProperty;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class IswcTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[11];
+        Iswc.TryGenerate(new GenerationOptions { Seed = 1 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        Iswc.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_Check()
+    {
+        Span<char> dst = stackalloc char[11];
+        Iswc.TryGenerate(new GenerationOptions { Seed = 2 }, dst, out var w).ShouldBeTrue();
+        dst[10] = dst[10] == '0' ? '1' : '0';
+        var s = new string(dst[..w]);
+        Iswc.TryValidate(s, out var r).ShouldBeFalse();
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/IntellectualProperty/PatentApplicationNumberTests.cs
+++ b/test/Veritas.Tests/IntellectualProperty/PatentApplicationNumberTests.cs
@@ -1,0 +1,24 @@
+using Veritas.IntellectualProperty;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class PatentApplicationNumberTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[10];
+        PatentApplicationNumber.TryGenerate(new GenerationOptions { Seed = 3 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        PatentApplicationNumber.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_Format()
+    {
+        PatentApplicationNumber.TryValidate("1A00000000", out var r).ShouldBeFalse();
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/IntellectualProperty/PatentPublicationNumberTests.cs
+++ b/test/Veritas.Tests/IntellectualProperty/PatentPublicationNumberTests.cs
@@ -1,0 +1,24 @@
+using Veritas.IntellectualProperty;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class PatentPublicationNumberTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[11];
+        PatentPublicationNumber.TryGenerate(new GenerationOptions { Seed = 4 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        PatentPublicationNumber.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_Format()
+    {
+        PatentPublicationNumber.TryValidate("USABC12345", out var r).ShouldBeFalse();
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/IntellectualProperty/SG/IpApplicationNumberTests.cs
+++ b/test/Veritas.Tests/IntellectualProperty/SG/IpApplicationNumberTests.cs
@@ -1,4 +1,4 @@
-using Veritas.IP.Singapore;
+using Veritas.IntellectualProperty.SG;
 using Veritas;
 using Shouldly;
 using Xunit;

--- a/test/Veritas.Tests/IntellectualProperty/TrademarkRegistrationNumberTests.cs
+++ b/test/Veritas.Tests/IntellectualProperty/TrademarkRegistrationNumberTests.cs
@@ -1,0 +1,24 @@
+using Veritas.IntellectualProperty;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class TrademarkRegistrationNumberTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[8];
+        TrademarkRegistrationNumber.TryGenerate(new GenerationOptions { Seed = 5 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        TrademarkRegistrationNumber.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_Format()
+    {
+        TrademarkRegistrationNumber.TryValidate("12345678", out var r).ShouldBeFalse();
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/Legal/EU/EcliTests.cs
+++ b/test/Veritas.Tests/Legal/EU/EcliTests.cs
@@ -1,0 +1,24 @@
+using Veritas.Legal.EU;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class EcliTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[30];
+        Ecli.TryGenerate(new GenerationOptions { Seed = 7 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        Ecli.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_Format()
+    {
+        Ecli.TryValidate("ECLI-NO-CODE", out var r).ShouldBeFalse();
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/Legal/EU/EuropeanPatentOfficePublicationIdTests.cs
+++ b/test/Veritas.Tests/Legal/EU/EuropeanPatentOfficePublicationIdTests.cs
@@ -1,0 +1,24 @@
+using Veritas.Legal.EU;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class EuropeanPatentOfficePublicationIdTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[11];
+        EuropeanPatentOfficePublicationId.TryGenerate(new GenerationOptions { Seed = 9 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        EuropeanPatentOfficePublicationId.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_Format()
+    {
+        EuropeanPatentOfficePublicationId.TryValidate("EP1234567", out var r).ShouldBeFalse();
+        r.IsValid.ShouldBeFalse();
+    }
+}

--- a/test/Veritas.Tests/Legal/US/CourtCaseNumberTests.cs
+++ b/test/Veritas.Tests/Legal/US/CourtCaseNumberTests.cs
@@ -1,0 +1,24 @@
+using Veritas.Legal.US;
+using Veritas;
+using Shouldly;
+using Xunit;
+
+public class CourtCaseNumberTests
+{
+    [Fact]
+    public void Generate_Validates()
+    {
+        Span<char> dst = stackalloc char[11];
+        CourtCaseNumber.TryGenerate(new GenerationOptions { Seed = 8 }, dst, out var w).ShouldBeTrue();
+        var s = new string(dst[..w]);
+        CourtCaseNumber.TryValidate(s, out var r).ShouldBeTrue();
+        r.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Invalid_Format()
+    {
+        CourtCaseNumber.TryValidate("2023-12345", out var r).ShouldBeFalse();
+        r.IsValid.ShouldBeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- rename IP module to IntellectualProperty and add global IP identifiers (ISWC, patent application/publication numbers, trademarks, copyrights)
- introduce legal namespace with ECLI, court case numbers, and EPO publication IDs
- reorganize country-specific identifiers into ISO code subfolders and update docs

## Testing
- `dotnet format --verify-no-changes --verbosity normal`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d8cabfa8832b93c9ba81ad8c7d9e